### PR TITLE
Fix return value of basic implementation and dead loop in rand update test

### DIFF
--- a/include/multi_buffer.h
+++ b/include/multi_buffer.h
@@ -112,6 +112,7 @@ typedef enum {
 #define hash_ctx_digest(ctx)     ((ctx)->job.result_digest)
 #define hash_ctx_processing(ctx) ((ctx)->status & HASH_CTX_STS_PROCESSING)
 #define hash_ctx_complete(ctx)   ((ctx)->status == HASH_CTX_STS_COMPLETE)
+#define hash_ctx_idle(ctx)   ((ctx)->status == HASH_CTX_STS_IDLE)
 #define hash_ctx_status(ctx)     ((ctx)->status)
 #define hash_ctx_error(ctx)      ((ctx)->error)
 #define hash_ctx_init(ctx) \

--- a/md5_mb/md5_ctx_base.c
+++ b/md5_mb/md5_ctx_base.c
@@ -70,16 +70,19 @@ MD5_HASH_CTX *md5_ctx_mgr_submit_base(MD5_HASH_CTX_MGR * mgr, MD5_HASH_CTX * ctx
 	if (flags & (~HASH_ENTIRE)) {
 		// User should not pass anything other than FIRST, UPDATE, or LAST
 		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_PROCESSING) && (flags == HASH_ENTIRE)) {
 		// Cannot submit a new entire job to a currently processing job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
 		// Cannot update a finished job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
 	}
 
 	if (flags == HASH_FIRST) {
@@ -140,6 +143,7 @@ static uint32_t md5_update(MD5_HASH_CTX * ctx, const void *buffer, uint32_t len)
 		ctx->total_length += 64;
 	}
 
+	ctx->status = HASH_CTX_STS_IDLE;
 	ctx->incoming_buffer = buffer;
 	return remain_len;
 }

--- a/md5_mb/md5_mb_rand_update_test.c
+++ b/md5_mb/md5_mb_rand_update_test.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "md5_mb.h"
+#include <assert.h>
 
 #define TEST_LEN  (1024*1024)
 #define TEST_BUFS 100
@@ -118,13 +119,28 @@ int main(void)
 						 buf_ptr[i], UPDATE_SIZE, HASH_UPDATE);
 
 		// Add jobs while available or finished
-		if ((ctx == NULL) || hash_ctx_complete(ctx)) {
-			i++;
+		if (ctx != NULL && hash_ctx_idle(ctx)) {
+			// Resubmit unfinished job
+			i = (unsigned long)(ctx->user_data);
+			buf_ptr[i] += UPDATE_SIZE;
 			continue;
 		}
-		// Resubmit unfinished job
-		i = (unsigned long)(ctx->user_data);
-		buf_ptr[i] += UPDATE_SIZE;
+		if (ctx) {
+			assert(ctx->error == 0);
+		}
+
+		/* ctx is null or ctx is free
+		 * Both cases mean free lane are available
+		 * try to find out the next job and submit it
+		 */
+		for (; i < TEST_BUFS; i++) {
+			ctx = &ctxpool[i];
+			// Add jobs that is not started
+			if (hash_ctx_complete(ctx)
+			    && buf_ptr[i] == bufs[i]) {
+				break;
+			}
+		}
 	}
 
 	// Start flushing finished jobs, end on last flushed

--- a/sha1_mb/sha1_ctx_base.c
+++ b/sha1_mb/sha1_ctx_base.c
@@ -86,16 +86,19 @@ SHA1_HASH_CTX *sha1_ctx_mgr_submit_base(SHA1_HASH_CTX_MGR * mgr, SHA1_HASH_CTX *
 	if (flags & (~HASH_ENTIRE)) {
 		// User should not pass anything other than FIRST, UPDATE, or LAST
 		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_PROCESSING) && (flags == HASH_ENTIRE)) {
 		// Cannot submit a new entire job to a currently processing job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
 		// Cannot update a finished job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
 	}
 
 	if (flags == HASH_FIRST) {
@@ -157,6 +160,7 @@ static uint32_t sha1_update(SHA1_HASH_CTX * ctx, const void *buffer, uint32_t le
 		ctx->total_length += SHA1_BLOCK_SIZE;
 	}
 
+	ctx->status = HASH_CTX_STS_IDLE;
 	ctx->incoming_buffer = buffer;
 	return remain_len;
 }

--- a/sha1_mb/sha1_mb_rand_update_test.c
+++ b/sha1_mb/sha1_mb_rand_update_test.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "sha1_mb.h"
+#include <assert.h>
 
 #define TEST_LEN  (1024*1024)
 #define TEST_BUFS 100
@@ -116,15 +117,29 @@ int main(void)
 			ctx = sha1_ctx_mgr_submit(mgr,
 						  &ctxpool[i],
 						  buf_ptr[i], UPDATE_SIZE, HASH_UPDATE);
-
-		// Add jobs while available or finished
-		if ((ctx == NULL) || hash_ctx_complete(ctx)) {
-			i++;
+		if (ctx != NULL && hash_ctx_idle(ctx)) {
+			// Resubmit unfinished job
+			i = (unsigned long)(ctx->user_data);
+			buf_ptr[i] += UPDATE_SIZE;
 			continue;
 		}
-		// Resubmit unfinished job
-		i = (unsigned long)(ctx->user_data);
-		buf_ptr[i] += UPDATE_SIZE;
+		if (ctx) {
+			assert(ctx->error == 0);
+		}
+
+		/* ctx is null or ctx is free
+		 * Both cases mean free lane are available
+		 * try to find out the next job and submit it
+		 */
+		for (; i < TEST_BUFS; i++) {
+			ctx = &ctxpool[i];
+			// Add jobs that is not started
+			if (hash_ctx_complete(ctx)
+			    && buf_ptr[i] == bufs[i]) {
+				break;
+			}
+		}
+
 	}
 
 	// Start flushing finished jobs, end on last flushed

--- a/sha256_mb/sha256_ctx_base.c
+++ b/sha256_mb/sha256_ctx_base.c
@@ -77,16 +77,19 @@ SHA256_HASH_CTX *sha256_ctx_mgr_submit_base(SHA256_HASH_CTX_MGR * mgr, SHA256_HA
 	if (flags & (~HASH_ENTIRE)) {
 		// User should not pass anything other than FIRST, UPDATE, or LAST
 		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_PROCESSING) && (flags == HASH_ENTIRE)) {
 		// Cannot submit a new entire job to a currently processing job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
 		// Cannot update a finished job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
 	}
 
 	if (flags == HASH_FIRST) {
@@ -147,7 +150,7 @@ static uint32_t sha256_update(SHA256_HASH_CTX * ctx, const void *buffer, uint32_
 		remain_len -= SHA256_BLOCK_SIZE;
 		ctx->total_length += SHA256_BLOCK_SIZE;
 	}
-
+	ctx->status = HASH_CTX_STS_IDLE;
 	ctx->incoming_buffer = buffer;
 	return remain_len;
 }

--- a/sha512_mb/sha512_ctx_base.c
+++ b/sha512_mb/sha512_ctx_base.c
@@ -96,16 +96,19 @@ SHA512_HASH_CTX *sha512_ctx_mgr_submit_base(SHA512_HASH_CTX_MGR * mgr, SHA512_HA
 	if (flags & (~HASH_ENTIRE)) {
 		// User should not pass anything other than FIRST, UPDATE, or LAST
 		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_PROCESSING) && (flags == HASH_ENTIRE)) {
 		// Cannot submit a new entire job to a currently processing job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
 	}
 
 	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
 		// Cannot update a finished job.
 		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
 	}
 
 	if (flags == HASH_FIRST) {
@@ -166,7 +169,7 @@ static uint32_t sha512_update(SHA512_HASH_CTX * ctx, const void *buffer, uint32_
 		remain_len -= SHA512_BLOCK_SIZE;
 		ctx->total_length += SHA512_BLOCK_SIZE;
 	}
-
+	ctx->status = HASH_CTX_STS_IDLE;
 	ctx->incoming_buffer = buffer;
 	return remain_len;
 }

--- a/sha512_mb/sha512_mb_rand_update_test.c
+++ b/sha512_mb/sha512_mb_rand_update_test.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "sha512_mb.h"
+#include <assert.h>
 
 #define TEST_LEN  (1024*1024)
 #define TEST_BUFS 100
@@ -117,15 +118,28 @@ int main(void)
 			ctx = sha512_ctx_mgr_submit(mgr,
 						    &ctxpool[i],
 						    buf_ptr[i], UPDATE_SIZE, HASH_UPDATE);
-
-		// Add jobs while available or finished
-		if ((ctx == NULL) || hash_ctx_complete(ctx)) {
-			i++;
+		if (ctx != NULL && hash_ctx_idle(ctx)) {
+			// Resubmit unfinished job
+			i = (unsigned long)(ctx->user_data);
+			buf_ptr[i] += UPDATE_SIZE;
 			continue;
 		}
-		// Resubmit unfinished job
-		i = (unsigned long)(ctx->user_data);
-		buf_ptr[i] += UPDATE_SIZE;
+		if (ctx) {
+			assert(ctx->error == 0);
+		}
+
+		/* ctx is null or ctx is free
+		 * Both cases mean free lane are available
+		 * try to find out the next job and submit it
+		 */
+		for (; i < TEST_BUFS; i++) {
+			ctx = &ctxpool[i];
+			// Add jobs that is not started
+			if (hash_ctx_complete(ctx)
+			    && buf_ptr[i] == bufs[i]) {
+				break;
+			}
+		}
 	}
 
 	// Start flushing finished jobs, end on last flushed


### PR DESCRIPTION
Multi-Buffer's base implementation function's return value is not right .
The commit will fix it .

Rand update test for SHA assume the return sequence . 
If the return finished job is not as expected . The test 
will fail .

To reproduce the issue , please modify unused_lanes from 0xf3210 to 0xf0123