### PR TITLE
Implement SHA256/512 multi-buffer with Arm64 crypto extention 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,9 +34,10 @@ perf_tests32=
 # Include units
 include sha1_mb/Makefile.am
 include mh_sha1/Makefile.am
+include sha256_mb/Makefile.am
+
 if !CPU_AARCH64
 include md5_mb/Makefile.am
-include sha256_mb/Makefile.am
 include sha512_mb/Makefile.am
 include mh_sha1_murmur3_x64_128/Makefile.am
 include mh_sha256/Makefile.am

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,10 +35,10 @@ perf_tests32=
 include sha1_mb/Makefile.am
 include mh_sha1/Makefile.am
 include sha256_mb/Makefile.am
+include sha512_mb/Makefile.am
 
 if !CPU_AARCH64
 include md5_mb/Makefile.am
-include sha512_mb/Makefile.am
 include mh_sha1_murmur3_x64_128/Makefile.am
 include mh_sha256/Makefile.am
 include aes/Makefile.am

--- a/Makefile.unx
+++ b/Makefile.unx
@@ -29,7 +29,7 @@
 
 units_x86_64     = sha1_mb sha256_mb sha512_mb md5_mb mh_sha1 mh_sha1_murmur3_x64_128 mh_sha256 aes rolling_hash
 units_x86_32     = $(units_x86_64)
-units_aarch64    = sha1_mb mh_sha1 sha256_mb
+units_aarch64    = sha1_mb mh_sha1 sha256_mb sha512_mb
 host_cpu ?= $(shell uname -m | sed -e 's/amd/x86_/')
 units ?= $(units_$(host_cpu))
 default: lib

--- a/Makefile.unx
+++ b/Makefile.unx
@@ -29,7 +29,7 @@
 
 units_x86_64     = sha1_mb sha256_mb sha512_mb md5_mb mh_sha1 mh_sha1_murmur3_x64_128 mh_sha256 aes rolling_hash
 units_x86_32     = $(units_x86_64)
-units_aarch64    = sha1_mb mh_sha1
+units_aarch64    = sha1_mb mh_sha1 sha256_mb
 host_cpu ?= $(shell uname -m | sed -e 's/amd/x86_/')
 units ?= $(units_$(host_cpu))
 default: lib

--- a/make.inc
+++ b/make.inc
@@ -97,7 +97,7 @@ endif
 
 ifeq ($(arch),aarch64)
   AS=gcc
-  SIM=
+  SIM=$(EXEC_WRAPPER)
 endif
 
 INCLUDE   = $(patsubst %,-I%/,$(subst :, ,$(VPATH)))
@@ -148,8 +148,10 @@ other: $(notdir $(other_tests))
 tests: $(all_unit_tests)
 perfs: $(all_perf_tests)
 checks: $(all_check_tests)
+ifneq ($(host_cpu),aarch64)
 check test perf: SIM=
 trace: SIMFLAGS = -debugtrace
+endif
 check test sim:
 	@echo Finished running $@
 

--- a/sha256_mb/Makefile.am
+++ b/sha256_mb/Makefile.am
@@ -65,9 +65,20 @@ lsrc_x86_64 += 	sha256_mb/sha256_ni_x1.asm \
 
 lsrc_x86_32 += 	$(lsrc_x86_64)
 
-lsrc_aarch64 += sha256_mb/sha256_ctx_base_aliases.c	\
-		sha256_mb/sha256_ctx_base.c
+lsrc_aarch64 += sha256_mb/sha256_ctx_base.c \
+		sha256_mb/sha256_ref.c
 
+lsrc_aarch64 += sha256_mb/aarch64/sha256_mb_multibinary.S \
+		sha256_mb/aarch64/sha256_mb_dispatch_init.c  \
+		sha256_mb/aarch64/sha256_ctx_ce.c	\
+		sha256_mb/aarch64/sha256_mb_mgr_ce.c	\
+		sha256_mb/aarch64/sha256_mb_x1_ce.S	\
+		sha256_mb/aarch64/sha256_mb_x2_ce.S	\
+		sha256_mb/aarch64/sha256_mb_x3_ce.S	\
+		sha256_mb/aarch64/sha256_mb_x4_ce.S
+
+
+lsrc_base_aliases += sha256_mb/sha256_ctx_base_aliases.c
 src_include += -I $(srcdir)/sha256_mb
 
 extern_hdrs +=  include/sha256_mb.h \

--- a/sha256_mb/Makefile.am
+++ b/sha256_mb/Makefile.am
@@ -65,7 +65,8 @@ lsrc_x86_64 += 	sha256_mb/sha256_ni_x1.asm \
 
 lsrc_x86_32 += 	$(lsrc_x86_64)
 
-lsrc_aarch64 += sha256_mb/sha256_ctx_base.c
+lsrc_aarch64 += sha256_mb/sha256_ctx_base_aliases.c	\
+		sha256_mb/sha256_ctx_base.c
 
 src_include += -I $(srcdir)/sha256_mb
 

--- a/sha256_mb/aarch64/sha256_ctx_ce.c
+++ b/sha256_mb/aarch64/sha256_ctx_ce.c
@@ -1,0 +1,255 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdint.h>
+#include <string.h>
+#include "sha256_mb.h"
+#include "memcpy_inline.h"
+
+void sha256_mb_mgr_init_ce(SHA256_MB_JOB_MGR * state);
+SHA256_JOB *sha256_mb_mgr_submit_ce(SHA256_MB_JOB_MGR * state, SHA256_JOB * job);
+SHA256_JOB *sha256_mb_mgr_flush_ce(SHA256_MB_JOB_MGR * state);
+static inline void hash_init_digest(SHA256_WORD_T * digest);
+static inline uint32_t hash_pad(uint8_t padblock[SHA256_BLOCK_SIZE * 2], uint64_t total_len);
+static SHA256_HASH_CTX *sha256_ctx_mgr_resubmit(SHA256_HASH_CTX_MGR * mgr,
+						SHA256_HASH_CTX * ctx);
+
+void sha256_ctx_mgr_init_ce(SHA256_HASH_CTX_MGR * mgr)
+{
+	sha256_mb_mgr_init_ce(&mgr->mgr);
+}
+
+SHA256_HASH_CTX *sha256_ctx_mgr_submit_ce(SHA256_HASH_CTX_MGR * mgr, SHA256_HASH_CTX * ctx,
+					  const void *buffer, uint32_t len,
+					  HASH_CTX_FLAG flags)
+{
+	if (flags & (~HASH_ENTIRE)) {
+		// User should not pass anything other than FIRST, UPDATE, or LAST
+		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
+	}
+
+	if (ctx->status & HASH_CTX_STS_PROCESSING) {
+		// Cannot submit to a currently processing job.
+		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
+	}
+
+	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
+		// Cannot update a finished job.
+		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
+	}
+
+	if (flags & HASH_FIRST) {
+		// Init digest
+		hash_init_digest(ctx->job.result_digest);
+
+		// Reset byte counter
+		ctx->total_length = 0;
+
+		// Clear extra blocks
+		ctx->partial_block_buffer_length = 0;
+	}
+	// If we made it here, there were no errors during this call to submit
+	ctx->error = HASH_CTX_ERROR_NONE;
+
+	// Store buffer ptr info from user
+	ctx->incoming_buffer = buffer;
+	ctx->incoming_buffer_length = len;
+
+	// Store the user's request flags and mark this ctx as currently being processed.
+	ctx->status = (flags & HASH_LAST) ?
+	    (HASH_CTX_STS) (HASH_CTX_STS_PROCESSING | HASH_CTX_STS_LAST) :
+	    HASH_CTX_STS_PROCESSING;
+
+	// Advance byte counter
+	ctx->total_length += len;
+
+	// If there is anything currently buffered in the extra blocks, append to it until it contains a whole block.
+	// Or if the user's buffer contains less than a whole block, append as much as possible to the extra block.
+	if ((ctx->partial_block_buffer_length) | (len < SHA256_BLOCK_SIZE)) {
+		// Compute how many bytes to copy from user buffer into extra block
+		uint32_t copy_len = SHA256_BLOCK_SIZE - ctx->partial_block_buffer_length;
+		if (len < copy_len)
+			copy_len = len;
+
+		if (copy_len) {
+			// Copy and update relevant pointers and counters
+			memcpy_fixedlen(&ctx->partial_block_buffer
+					[ctx->partial_block_buffer_length], buffer, copy_len);
+
+			ctx->partial_block_buffer_length += copy_len;
+			ctx->incoming_buffer = (const void *)((const char *)buffer + copy_len);
+			ctx->incoming_buffer_length = len - copy_len;
+		}
+		// The extra block should never contain more than 1 block here
+		assert(ctx->partial_block_buffer_length <= SHA256_BLOCK_SIZE);
+
+		// If the extra block buffer contains exactly 1 block, it can be hashed.
+		if (ctx->partial_block_buffer_length >= SHA256_BLOCK_SIZE) {
+			ctx->partial_block_buffer_length = 0;
+
+			ctx->job.buffer = ctx->partial_block_buffer;
+			ctx->job.len = 1;
+
+			ctx =
+			    (SHA256_HASH_CTX *) sha256_mb_mgr_submit_ce(&mgr->mgr, &ctx->job);
+		}
+	}
+
+	return sha256_ctx_mgr_resubmit(mgr, ctx);
+}
+
+SHA256_HASH_CTX *sha256_ctx_mgr_flush_ce(SHA256_HASH_CTX_MGR * mgr)
+{
+	SHA256_HASH_CTX *ctx;
+
+	while (1) {
+		ctx = (SHA256_HASH_CTX *) sha256_mb_mgr_flush_ce(&mgr->mgr);
+
+		// If flush returned 0, there are no more jobs in flight.
+		if (!ctx)
+			return NULL;
+
+		// If flush returned a job, verify that it is safe to return to the user.
+		// If it is not ready, resubmit the job to finish processing.
+		ctx = sha256_ctx_mgr_resubmit(mgr, ctx);
+
+		// If sha256_ctx_mgr_resubmit returned a job, it is ready to be returned.
+		if (ctx)
+			return ctx;
+
+		// Otherwise, all jobs currently being managed by the SHA256_HASH_CTX_MGR still need processing. Loop.
+	}
+}
+
+static SHA256_HASH_CTX *sha256_ctx_mgr_resubmit(SHA256_HASH_CTX_MGR * mgr,
+						SHA256_HASH_CTX * ctx)
+{
+	while (ctx) {
+
+		if (ctx->status & HASH_CTX_STS_COMPLETE) {
+			ctx->status = HASH_CTX_STS_COMPLETE;	// Clear PROCESSING bit
+			return ctx;
+		}
+		// If the extra blocks are empty, begin hashing what remains in the user's buffer.
+		if (ctx->partial_block_buffer_length == 0 && ctx->incoming_buffer_length) {
+			const void *buffer = ctx->incoming_buffer;
+			uint32_t len = ctx->incoming_buffer_length;
+
+			// Only entire blocks can be hashed. Copy remainder to extra blocks buffer.
+			uint32_t copy_len = len & (SHA256_BLOCK_SIZE - 1);
+
+			if (copy_len) {
+				len -= copy_len;
+				memcpy_fixedlen(ctx->partial_block_buffer,
+						((const char *)buffer + len), copy_len);
+				ctx->partial_block_buffer_length = copy_len;
+			}
+
+			ctx->incoming_buffer_length = 0;
+
+			// len should be a multiple of the block size now
+			assert((len % SHA256_BLOCK_SIZE) == 0);
+
+			// Set len to the number of blocks to be hashed in the user's buffer
+			len >>= SHA256_LOG2_BLOCK_SIZE;
+
+			if (len) {
+				ctx->job.buffer = (uint8_t *) buffer;
+				ctx->job.len = len;
+				ctx = (SHA256_HASH_CTX *) sha256_mb_mgr_submit_ce(&mgr->mgr,
+										  &ctx->job);
+				continue;
+			}
+		}
+		// If the extra blocks are not empty, then we are either on the last block(s)
+		// or we need more user input before continuing.
+		if (ctx->status & HASH_CTX_STS_LAST) {
+			uint8_t *buf = ctx->partial_block_buffer;
+			uint32_t n_extra_blocks = hash_pad(buf, ctx->total_length);
+
+			ctx->status =
+			    (HASH_CTX_STS) (HASH_CTX_STS_PROCESSING | HASH_CTX_STS_COMPLETE);
+			ctx->job.buffer = buf;
+			ctx->job.len = (uint32_t) n_extra_blocks;
+			ctx =
+			    (SHA256_HASH_CTX *) sha256_mb_mgr_submit_ce(&mgr->mgr, &ctx->job);
+			continue;
+		}
+
+		if (ctx)
+			ctx->status = HASH_CTX_STS_IDLE;
+		return ctx;
+	}
+
+	return NULL;
+}
+
+static inline void hash_init_digest(SHA256_WORD_T * digest)
+{
+	static const SHA256_WORD_T hash_initial_digest[SHA256_DIGEST_NWORDS] =
+	    { SHA256_INITIAL_DIGEST };
+	memcpy_fixedlen(digest, hash_initial_digest, sizeof(hash_initial_digest));
+}
+
+static inline uint32_t hash_pad(uint8_t padblock[SHA256_BLOCK_SIZE * 2], uint64_t total_len)
+{
+	uint32_t i = (uint32_t) (total_len & (SHA256_BLOCK_SIZE - 1));
+
+	memclr_fixedlen(&padblock[i], SHA256_BLOCK_SIZE);
+	padblock[i] = 0x80;
+
+	// Move i to the end of either 1st or 2nd extra block depending on length
+	i += ((SHA256_BLOCK_SIZE - 1) & (0 - (total_len + SHA256_PADLENGTHFIELD_SIZE + 1))) +
+	    1 + SHA256_PADLENGTHFIELD_SIZE;
+
+#if SHA256_PADLENGTHFIELD_SIZE == 16
+	*((uint64_t *) & padblock[i - 16]) = 0;
+#endif
+
+	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+
+	return i >> SHA256_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
+}
+
+struct slver {
+	uint16_t snum;
+	uint8_t ver;
+	uint8_t core;
+};
+struct slver sha256_ctx_mgr_init_ce_slver_02020142;
+struct slver sha256_ctx_mgr_init_ce_slver = { 0x0142, 0x02, 0x02 };
+
+struct slver sha256_ctx_mgr_submit_ce_slver_02020143;
+struct slver sha256_ctx_mgr_submit_ce_slver = { 0x0143, 0x02, 0x02 };
+
+struct slver sha256_ctx_mgr_flush_ce_slver_02020144;
+struct slver sha256_ctx_mgr_flush_ce_slver = { 0x0144, 0x02, 0x02 };

--- a/sha256_mb/aarch64/sha256_mb_dispatch_init.c
+++ b/sha256_mb/aarch64/sha256_mb_dispatch_init.c
@@ -1,0 +1,61 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stdint.h>
+#include <string.h>
+#include "sha256_mb.h"
+#include "memcpy_inline.h"
+
+extern void sha256_ctx_mgr_init_ce(SHA256_HASH_CTX_MGR * mgr);
+extern SHA256_HASH_CTX *sha256_ctx_mgr_submit_ce(SHA256_HASH_CTX_MGR * mgr,
+						 SHA256_HASH_CTX * ctx, const void *buffer,
+						 uint32_t len, HASH_CTX_FLAG flags);
+extern SHA256_HASH_CTX *sha256_ctx_mgr_flush_ce(SHA256_HASH_CTX_MGR * mgr);
+
+extern typeof(sha256_ctx_mgr_init_ce) * sha256_ctx_mgr_init_dispatched;
+void sha256_ctx_mgr_init_dispatch_init(SHA256_HASH_CTX_MGR * mgr)
+{
+	sha256_ctx_mgr_init_dispatched = sha256_ctx_mgr_init_ce;
+	return sha256_ctx_mgr_init_dispatched(mgr);
+}
+
+extern typeof(sha256_ctx_mgr_submit_ce) * sha256_ctx_mgr_submit_dispatched;
+SHA256_HASH_CTX *sha256_ctx_mgr_submit_dispatch_init(SHA256_HASH_CTX_MGR * mgr,
+						     SHA256_HASH_CTX * ctx, const void *buffer,
+						     uint32_t len, HASH_CTX_FLAG flags)
+{
+	sha256_ctx_mgr_submit_dispatched = sha256_ctx_mgr_submit_ce;
+	return sha256_ctx_mgr_submit_dispatched(mgr, ctx, buffer, len, flags);
+}
+
+extern typeof(sha256_ctx_mgr_flush_ce) * sha256_ctx_mgr_flush_dispatched;
+SHA256_HASH_CTX *sha256_ctx_mgr_flush_dispatch_init(SHA256_HASH_CTX_MGR * mgr)
+{
+	sha256_ctx_mgr_flush_dispatched = sha256_ctx_mgr_flush_ce;
+	return sha256_ctx_mgr_flush_dispatched(mgr);
+}

--- a/sha256_mb/aarch64/sha256_mb_mgr_ce.c
+++ b/sha256_mb/aarch64/sha256_mb_mgr_ce.c
@@ -1,0 +1,254 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stddef.h>
+#include <sha256_mb.h>
+#include <assert.h>
+
+#ifndef max
+#define max(a,b)            (((a) > (b)) ? (a) : (b))
+#endif
+
+#ifndef min
+#define min(a,b)            (((a) < (b)) ? (a) : (b))
+#endif
+
+#define SHA256_MB_CE_MAX_LANES	3
+
+#if SHA256_MB_CE_MAX_LANES >=4
+void sha256_mb_ce_x4(SHA256_JOB *, SHA256_JOB *, SHA256_JOB *, SHA256_JOB *, int);
+#endif
+#if SHA256_MB_CE_MAX_LANES >=3
+void sha256_mb_ce_x3(SHA256_JOB *, SHA256_JOB *, SHA256_JOB *, int);
+#endif
+#if SHA256_MB_CE_MAX_LANES >=2
+void sha256_mb_ce_x2(SHA256_JOB *, SHA256_JOB *, int);
+#endif
+void sha256_mb_ce_x1(SHA256_JOB *, int);
+
+#define LANE_IS_NOT_FINISHED(state,i)  	\
+	(((state->lens[i]&(~0xf))!=0) && state->ldata[i].job_in_lane!=NULL)
+#define LANE_IS_FINISHED(state,i)  	\
+	(((state->lens[i]&(~0xf))==0) && state->ldata[i].job_in_lane!=NULL)
+#define	LANE_IS_FREE(state,i)		\
+	(((state->lens[i]&(~0xf))==0) && state->ldata[i].job_in_lane==NULL)
+#define LANE_IS_INVALID(state,i)	\
+	(((state->lens[i]&(~0xf))!=0) && state->ldata[i].job_in_lane==NULL)
+void sha256_mb_mgr_init_ce(SHA256_MB_JOB_MGR * state)
+{
+	int i;
+
+	state->unused_lanes = 0xf;
+	state->num_lanes_inuse = 0;
+	for (i = SHA256_MB_CE_MAX_LANES - 1; i >= 0; i--) {
+		state->unused_lanes <<= 4;
+		state->unused_lanes |= i;
+		state->lens[i] = i;
+		state->ldata[i].job_in_lane = 0;
+	}
+
+	//lanes > SHA1_MB_CE_MAX_LANES is invalid lane
+	for (i = SHA256_MB_CE_MAX_LANES; i < SHA256_MAX_LANES; i++) {
+		state->lens[i] = 0xf;
+		state->ldata[i].job_in_lane = 0;
+	}
+}
+
+static int sha256_mb_mgr_do_jobs(SHA256_MB_JOB_MGR * state)
+{
+	int lane_idx, len, i, lanes;
+
+	int lane_idx_array[SHA256_MAX_LANES];
+
+	if (state->num_lanes_inuse == 0) {
+		return -1;
+	}
+#if SHA256_MB_CE_MAX_LANES == 4
+	if (state->num_lanes_inuse == 4) {
+		len = min(min(state->lens[0], state->lens[1]),
+			  min(state->lens[2], state->lens[3]));
+		lane_idx = len & 0xf;
+		len &= ~0xf;
+
+		sha256_mb_ce_x4(state->ldata[0].job_in_lane,
+				state->ldata[1].job_in_lane,
+				state->ldata[2].job_in_lane,
+				state->ldata[3].job_in_lane, len >> 4);
+
+	} else
+#elif SHA256_MB_CE_MAX_LANES == 3
+	if (state->num_lanes_inuse == 3) {
+		len = min(min(state->lens[0], state->lens[1]), state->lens[2]);
+		lane_idx = len & 0xf;
+		len &= ~0xf;
+
+		sha256_mb_ce_x3(state->ldata[0].job_in_lane,
+				state->ldata[1].job_in_lane,
+				state->ldata[2].job_in_lane, len >> 4);
+
+	} else
+#elif	SHA256_MB_CE_MAX_LANES == 2
+	if (state->num_lanes_inuse == 2) {
+		len = min(state->lens[0], state->lens[1]);
+		lane_idx = len & 0xf;
+		len &= ~0xf;
+
+		sha256_mb_ce_x2(state->ldata[0].job_in_lane,
+				state->ldata[1].job_in_lane, len >> 4);
+
+	} else
+#endif
+	{
+		lanes = 0, len = 0;
+		for (i = 0; i < SHA256_MAX_LANES && lanes < state->num_lanes_inuse; i++) {
+			if (LANE_IS_NOT_FINISHED(state, i)) {
+				if (lanes)
+					len = min(len, state->lens[i]);
+				else
+					len = state->lens[i];
+				lane_idx_array[lanes] = i;
+				lanes++;
+			}
+		}
+		if (lanes == 0)
+			return -1;
+		lane_idx = len & 0xf;
+		len = len & (~0xf);
+#if SHA256_MB_CE_MAX_LANES >=4
+		if (lanes == 4) {
+			sha256_mb_ce_x4(state->ldata[lane_idx_array[0]].job_in_lane,
+					state->ldata[lane_idx_array[1]].job_in_lane,
+					state->ldata[lane_idx_array[2]].job_in_lane,
+					state->ldata[lane_idx_array[3]].job_in_lane, len >> 4);
+
+		} else
+#endif
+#if SHA256_MB_CE_MAX_LANES >=3
+		if (lanes == 3) {
+			sha256_mb_ce_x3(state->ldata[lane_idx_array[0]].job_in_lane,
+					state->ldata[lane_idx_array[1]].job_in_lane,
+					state->ldata[lane_idx_array[2]].job_in_lane, len >> 4);
+		} else
+#endif
+#if SHA256_MB_CE_MAX_LANES >=2
+		if (lanes == 2) {
+			sha256_mb_ce_x2(state->ldata[lane_idx_array[0]].job_in_lane,
+					state->ldata[lane_idx_array[1]].job_in_lane, len >> 4);
+		} else
+#endif
+		{
+			sha256_mb_ce_x1(state->ldata[lane_idx_array[0]].job_in_lane, len >> 4);
+		}
+	}
+	//only return the min length job
+	for (i = 0; i < SHA256_MAX_LANES; i++) {
+		if (LANE_IS_NOT_FINISHED(state, i)) {
+			state->lens[i] -= len;
+			state->ldata[i].job_in_lane->len -= len;
+			state->ldata[i].job_in_lane->buffer += len << 2;
+		}
+	}
+
+	return lane_idx;
+
+}
+
+static SHA256_JOB *sha256_mb_mgr_free_lane(SHA256_MB_JOB_MGR * state)
+{
+	int i;
+	SHA256_JOB *ret = NULL;
+
+	for (i = 0; i < SHA256_MB_CE_MAX_LANES; i++) {
+		if (LANE_IS_FINISHED(state, i)) {
+
+			state->unused_lanes <<= 4;
+			state->unused_lanes |= i;
+			state->num_lanes_inuse--;
+			ret = state->ldata[i].job_in_lane;
+			ret->status = STS_COMPLETED;
+			state->ldata[i].job_in_lane = NULL;
+			break;
+		}
+	}
+	return ret;
+}
+
+static void sha256_mb_mgr_insert_job(SHA256_MB_JOB_MGR * state, SHA256_JOB * job)
+{
+	int lane_idx;
+	//add job into lanes
+	lane_idx = state->unused_lanes & 0xf;
+	//fatal error
+	assert(lane_idx < SHA256_MB_CE_MAX_LANES);
+	state->lens[lane_idx] = (job->len << 4) | lane_idx;
+	state->ldata[lane_idx].job_in_lane = job;
+	state->unused_lanes >>= 4;
+	state->num_lanes_inuse++;
+}
+
+SHA256_JOB *sha256_mb_mgr_submit_ce(SHA256_MB_JOB_MGR * state, SHA256_JOB * job)
+{
+#ifndef NDEBUG
+	int lane_idx;
+#endif
+	SHA256_JOB *ret;
+
+	//add job into lanes
+	sha256_mb_mgr_insert_job(state, job);
+
+	ret = sha256_mb_mgr_free_lane(state);
+	if (ret != NULL) {
+		return ret;
+	}
+	//submit will wait all lane has data
+	if (state->num_lanes_inuse < SHA256_MB_CE_MAX_LANES)
+		return NULL;
+#ifndef NDEBUG
+	lane_idx = sha256_mb_mgr_do_jobs(state);
+	assert(lane_idx != -1);
+#else
+	sha256_mb_mgr_do_jobs(state);
+#endif
+
+	//~ i = lane_idx;
+	ret = sha256_mb_mgr_free_lane(state);
+	return ret;
+}
+
+SHA256_JOB *sha256_mb_mgr_flush_ce(SHA256_MB_JOB_MGR * state)
+{
+	SHA256_JOB *ret;
+	ret = sha256_mb_mgr_free_lane(state);
+	if (ret) {
+		return ret;
+	}
+
+	sha256_mb_mgr_do_jobs(state);
+	return sha256_mb_mgr_free_lane(state);
+
+}

--- a/sha256_mb/aarch64/sha256_mb_multibinary.S
+++ b/sha256_mb/aarch64/sha256_mb_multibinary.S
@@ -1,0 +1,36 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+
+#include "multibinary_arm.h"
+
+
+mbin_dispatch sha256_ctx_mgr_submit
+mbin_dispatch sha256_ctx_mgr_init
+mbin_dispatch sha256_ctx_mgr_flush

--- a/sha256_mb/aarch64/sha256_mb_x1_ce.S
+++ b/sha256_mb/aarch64/sha256_mb_x1_ce.S
@@ -1,0 +1,238 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+	.arch armv8-a+crypto
+	.text
+	.align	2
+	.p2align 3,,7
+
+/*
+Macros
+*/
+
+.macro	declare_var_vector_reg name:req,reg:req
+	\name\()_q	.req	q\reg
+	\name\()_v	.req	v\reg
+	\name\()_s	.req	s\reg
+.endm
+/**
+maros for round 48-63
+*/
+.macro sha256_4_rounds_high msg:req,tmp0:req,tmp1:req
+	ldr		key_q , [tmp]
+	mov		l0_tmp2_v.16b,l0_abcd_v.16b
+	add		tmp,tmp,16
+	add		l0_\tmp1\()_v.4s,l0_\msg\()_v.4s,key_v.4s
+	sha256h		l0_abcd_q,l0_efgh_q,l0_\tmp0\()_v.4s
+	sha256h2	l0_efgh_q,l0_tmp2_q,l0_\tmp0\()_v.4s
+
+.endm
+/**
+maros for round 0-47
+*/
+.macro sha256_4_rounds_low msg0:req,msg1:req,msg2:req,msg3:req,tmp0:req,tmp1:req
+	sha256su0		l0_\msg0\()_v.4s,l0_\msg1\()_v.4s
+	sha256_4_rounds_high	\msg1,\tmp0,\tmp1
+	sha256su1		l0_\msg0\()_v.4s,l0_\msg2\()_v.4s,l0_\msg3\()_v.4s
+.endm
+
+
+/*
+Variable list
+*/
+
+	declare_var_vector_reg	key,31
+
+
+/*
+digest variables
+*/
+	declare_var_vector_reg	l0_abcd,0
+	declare_var_vector_reg	l0_efgh,1
+	declare_var_vector_reg	l0_abcd_saved,5
+	declare_var_vector_reg	l0_efgh_saved,6
+/*
+Temporay variables
+*/
+	declare_var_vector_reg	l0_tmp0,2
+	declare_var_vector_reg	l0_tmp1,3
+	declare_var_vector_reg	l0_tmp2,4
+/*
+Message variables
+*/
+	declare_var_vector_reg	l0_msg0,16
+	declare_var_vector_reg	l0_msg1,17
+	declare_var_vector_reg	l0_msg2,18
+	declare_var_vector_reg	l0_msg3,19
+
+
+
+/*
+	void sha256_mb_ce_x1(SHA1_JOB * l0_job, int len);
+*/
+/*
+Arguements list
+*/
+	l0_job 	.req	x0
+	len	.req	w1
+	l0_data	.req	x2
+	tmp	.req	x3
+	.global	sha256_mb_ce_x1
+	.type	sha256_mb_ce_x1, %function
+sha256_mb_ce_x1:
+	ldr	l0_data, [l0_job]
+	ldr	l0_abcd_q, [l0_job, 64]
+	ldr	l0_efgh_q, [l0_job, 80]
+
+
+
+start_loop:
+	adr	tmp, KEY
+	//load msgs
+	ld1	{l0_msg0_v.4s-l0_msg3_v.4s},[l0_data]
+	ldr	key_q,[tmp]
+	add	tmp,tmp,16
+	//adjust loop parameter
+	add	l0_data,l0_data,64
+	sub	len, len, #1
+	cmp	len, 0
+	//backup digest
+	mov	l0_abcd_saved_v.16b,l0_abcd_v.16b
+	mov	l0_efgh_saved_v.16b,l0_efgh_v.16b
+
+	rev32	l0_msg0_v.16b,l0_msg0_v.16b
+	rev32	l0_msg1_v.16b,l0_msg1_v.16b
+	add	l0_tmp0_v.4s,l0_msg0_v.4s,key_v.4s
+	rev32	l0_msg2_v.16b,l0_msg2_v.16b
+	rev32	l0_msg3_v.16b,l0_msg3_v.16b
+
+
+
+	sha256_4_rounds_low	msg0,msg1,msg2,msg3,tmp0,tmp1    /* rounds 0-3 */
+	sha256_4_rounds_low	msg1,msg2,msg3,msg0,tmp1,tmp0
+	sha256_4_rounds_low	msg2,msg3,msg0,msg1,tmp0,tmp1
+	sha256_4_rounds_low	msg3,msg0,msg1,msg2,tmp1,tmp0
+
+	sha256_4_rounds_low	msg0,msg1,msg2,msg3,tmp0,tmp1    /* rounds 16-19 */
+	sha256_4_rounds_low	msg1,msg2,msg3,msg0,tmp1,tmp0
+	sha256_4_rounds_low	msg2,msg3,msg0,msg1,tmp0,tmp1
+	sha256_4_rounds_low	msg3,msg0,msg1,msg2,tmp1,tmp0
+	sha256_4_rounds_low	msg0,msg1,msg2,msg3,tmp0,tmp1    /* rounds 32-35 */
+	sha256_4_rounds_low	msg1,msg2,msg3,msg0,tmp1,tmp0
+	sha256_4_rounds_low	msg2,msg3,msg0,msg1,tmp0,tmp1
+	sha256_4_rounds_low	msg3,msg0,msg1,msg2,tmp1,tmp0
+
+	sha256_4_rounds_high	msg1,tmp0,tmp1			/* rounds 48-51 */
+	sha256_4_rounds_high	msg2,tmp1,tmp0
+	sha256_4_rounds_high	msg3,tmp0,tmp1
+
+	/* rounds 60-63 */
+	mov		l0_tmp2_v.16b,l0_abcd_v.16b
+	sha256h		l0_abcd_q,l0_efgh_q,l0_tmp1_v.4s
+	sha256h2	l0_efgh_q,l0_tmp2_q,l0_tmp1_v.4s
+
+
+
+	add     l0_abcd_v.4s,l0_abcd_v.4s,l0_abcd_saved_v.4s
+	add     l0_efgh_v.4s,l0_efgh_v.4s,l0_efgh_saved_v.4s
+
+
+	bgt	start_loop
+	str	l0_abcd_q,	[l0_job, 64]
+	str	l0_efgh_q, 	[l0_job, 80]
+
+	ret
+
+	.size	sha256_mb_ce_x1, .-sha256_mb_ce_x1
+	.section	.rol0_data.cst16,"aM",@progbits,16
+	.align	4
+KEY:
+	.word 0x428A2F98
+	.word 0x71374491
+	.word 0xB5C0FBCF
+	.word 0xE9B5DBA5
+	.word 0x3956C25B
+	.word 0x59F111F1
+	.word 0x923F82A4
+	.word 0xAB1C5ED5
+	.word 0xD807AA98
+	.word 0x12835B01
+	.word 0x243185BE
+	.word 0x550C7DC3
+	.word 0x72BE5D74
+	.word 0x80DEB1FE
+	.word 0x9BDC06A7
+	.word 0xC19BF174
+	.word 0xE49B69C1
+	.word 0xEFBE4786
+	.word 0x0FC19DC6
+	.word 0x240CA1CC
+	.word 0x2DE92C6F
+	.word 0x4A7484AA
+	.word 0x5CB0A9DC
+	.word 0x76F988DA
+	.word 0x983E5152
+	.word 0xA831C66D
+	.word 0xB00327C8
+	.word 0xBF597FC7
+	.word 0xC6E00BF3
+	.word 0xD5A79147
+	.word 0x06CA6351
+	.word 0x14292967
+	.word 0x27B70A85
+	.word 0x2E1B2138
+	.word 0x4D2C6DFC
+	.word 0x53380D13
+	.word 0x650A7354
+	.word 0x766A0ABB
+	.word 0x81C2C92E
+	.word 0x92722C85
+	.word 0xA2BFE8A1
+	.word 0xA81A664B
+	.word 0xC24B8B70
+	.word 0xC76C51A3
+	.word 0xD192E819
+	.word 0xD6990624
+	.word 0xF40E3585
+	.word 0x106AA070
+	.word 0x19A4C116
+	.word 0x1E376C08
+	.word 0x2748774C
+	.word 0x34B0BCB5
+	.word 0x391C0CB3
+	.word 0x4ED8AA4A
+	.word 0x5B9CCA4F
+	.word 0x682E6FF3
+	.word 0x748F82EE
+	.word 0x78A5636F
+	.word 0x84C87814
+	.word 0x8CC70208
+	.word 0x90BEFFFA
+	.word 0xA4506CEB
+	.word 0xBEF9A3F7
+	.word 0xC67178F2

--- a/sha256_mb/aarch64/sha256_mb_x2_ce.S
+++ b/sha256_mb/aarch64/sha256_mb_x2_ce.S
@@ -1,0 +1,289 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+	.arch armv8-a+crypto
+	.text
+	.align	2
+	.p2align 3,,7
+
+/*
+Macros
+*/
+
+.macro	declare_var_vector_reg name:req,reg:req
+	\name\()_q	.req	q\reg
+	\name\()_v	.req	v\reg
+	\name\()_s	.req	s\reg
+.endm
+/**
+maros for round 48-63
+*/
+.macro sha256_4_rounds_high msg:req,tmp0:req,tmp1:req
+	ldr		key_q , [tmp]
+	mov		l0_tmp2_v.16b,l0_abcd_v.16b
+	mov		l1_tmp2_v.16b,l1_abcd_v.16b
+	add		tmp,tmp,16
+	add		l0_\tmp1\()_v.4s,l0_\msg\()_v.4s,key_v.4s
+	add		l1_\tmp1\()_v.4s,l1_\msg\()_v.4s,key_v.4s
+	sha256h		l0_abcd_q,l0_efgh_q,l0_\tmp0\()_v.4s
+	sha256h		l1_abcd_q,l1_efgh_q,l1_\tmp0\()_v.4s
+	sha256h2	l0_efgh_q,l0_tmp2_q,l0_\tmp0\()_v.4s
+	sha256h2	l1_efgh_q,l1_tmp2_q,l1_\tmp0\()_v.4s
+
+.endm
+/**
+maros for round 0-47
+*/
+.macro sha256_4_rounds_low msg0:req,msg1:req,msg2:req,msg3:req,tmp0:req,tmp1:req
+	sha256su0		l0_\msg0\()_v.4s,l0_\msg1\()_v.4s
+	sha256su0		l1_\msg0\()_v.4s,l1_\msg1\()_v.4s
+	sha256_4_rounds_high	\msg1,\tmp0,\tmp1
+	sha256su1		l0_\msg0\()_v.4s,l0_\msg2\()_v.4s,l0_\msg3\()_v.4s
+	sha256su1		l1_\msg0\()_v.4s,l1_\msg2\()_v.4s,l1_\msg3\()_v.4s
+.endm
+
+
+/*
+Variable list
+*/
+
+	declare_var_vector_reg	key,31
+
+
+/*
+digest variables
+*/
+	declare_var_vector_reg	l0_abcd,0
+	declare_var_vector_reg	l0_efgh,1
+	declare_var_vector_reg	l0_abcd_saved,2
+	declare_var_vector_reg	l0_efgh_saved,3
+	declare_var_vector_reg	l1_abcd,4
+	declare_var_vector_reg	l1_efgh,5
+	declare_var_vector_reg	l1_abcd_saved,6
+	declare_var_vector_reg	l1_efgh_saved,7
+/*
+Temporay variables
+*/
+	declare_var_vector_reg	l0_tmp0,8
+	declare_var_vector_reg	l0_tmp1,9
+	declare_var_vector_reg	l0_tmp2,10
+	declare_var_vector_reg	l1_tmp0,11
+	declare_var_vector_reg	l1_tmp1,12
+	declare_var_vector_reg	l1_tmp2,13
+/*
+Message variables
+*/
+	declare_var_vector_reg	l0_msg0,16
+	declare_var_vector_reg	l0_msg1,17
+	declare_var_vector_reg	l0_msg2,18
+	declare_var_vector_reg	l0_msg3,19
+	declare_var_vector_reg	l1_msg0,20
+	declare_var_vector_reg	l1_msg1,21
+	declare_var_vector_reg	l1_msg2,22
+	declare_var_vector_reg	l1_msg3,23
+
+
+
+/*
+	void sha256_mb_ce_x2(SHA256_JOB *, SHA256_JOB *, int);
+*/
+/*
+Arguements list
+*/
+	l0_job 	.req	x0
+	l1_job 	.req	x1
+	len	.req	w2
+	l0_data	.req	x3
+	l1_data	.req	x4
+	tmp	.req	x5
+	.global	sha256_mb_ce_x2
+	.type	sha256_mb_ce_x2, %function
+sha256_mb_ce_x2:
+	//push d8~d15
+	stp 	d8,d9,[sp,-192]!
+	stp 	d10,d11,[sp,16]
+	stp 	d12,d13,[sp,32]
+	stp 	d14,d15,[sp,48]
+	ldr	l0_data, [l0_job]
+	ldr	l0_abcd_q, [l0_job, 64]
+	ldr	l0_efgh_q, [l0_job, 80]
+	ldr	l1_data,   [l1_job]
+	ldr	l1_abcd_q, [l1_job, 64]
+	ldr	l1_efgh_q, [l1_job, 80]
+
+
+
+start_loop:
+
+	//load key addr
+	adr	tmp, KEY
+	//load msgs
+	ld1	{l0_msg0_v.4s-l0_msg3_v.4s},[l0_data]
+	ld1	{l1_msg0_v.4s-l1_msg3_v.4s},[l1_data]
+	ldr	key_q,[tmp]
+	add	tmp,tmp,16
+	//adjust loop parameter
+	add	l0_data,l0_data,64
+	add	l1_data,l1_data,64
+	sub	len, len, #1
+	cmp	len, 0
+	//backup digest
+	mov	l0_abcd_saved_v.16b,l0_abcd_v.16b
+	mov	l0_efgh_saved_v.16b,l0_efgh_v.16b
+	mov	l1_abcd_saved_v.16b,l1_abcd_v.16b
+	mov	l1_efgh_saved_v.16b,l1_efgh_v.16b
+
+	rev32	l0_msg0_v.16b,l0_msg0_v.16b
+	rev32	l0_msg1_v.16b,l0_msg1_v.16b
+	add	l0_tmp0_v.4s, l0_msg0_v.4s,key_v.4s
+	rev32	l0_msg2_v.16b,l0_msg2_v.16b
+	rev32	l0_msg3_v.16b,l0_msg3_v.16b
+
+	rev32	l1_msg0_v.16b,l1_msg0_v.16b
+	rev32	l1_msg1_v.16b,l1_msg1_v.16b
+	add	l1_tmp0_v.4s, l1_msg0_v.4s,key_v.4s
+	rev32	l1_msg2_v.16b,l1_msg2_v.16b
+	rev32	l1_msg3_v.16b,l1_msg3_v.16b
+
+
+
+	sha256_4_rounds_low	msg0,msg1,msg2,msg3,tmp0,tmp1    /* rounds 0-3 */
+	sha256_4_rounds_low	msg1,msg2,msg3,msg0,tmp1,tmp0
+	sha256_4_rounds_low	msg2,msg3,msg0,msg1,tmp0,tmp1
+	sha256_4_rounds_low	msg3,msg0,msg1,msg2,tmp1,tmp0
+
+	sha256_4_rounds_low	msg0,msg1,msg2,msg3,tmp0,tmp1    /* rounds 16-19 */
+	sha256_4_rounds_low	msg1,msg2,msg3,msg0,tmp1,tmp0
+	sha256_4_rounds_low	msg2,msg3,msg0,msg1,tmp0,tmp1
+	sha256_4_rounds_low	msg3,msg0,msg1,msg2,tmp1,tmp0
+	sha256_4_rounds_low	msg0,msg1,msg2,msg3,tmp0,tmp1    /* rounds 32-35 */
+	sha256_4_rounds_low	msg1,msg2,msg3,msg0,tmp1,tmp0
+	sha256_4_rounds_low	msg2,msg3,msg0,msg1,tmp0,tmp1
+	sha256_4_rounds_low	msg3,msg0,msg1,msg2,tmp1,tmp0
+
+	sha256_4_rounds_high	msg1,tmp0,tmp1			/* rounds 48-51 */
+	sha256_4_rounds_high	msg2,tmp1,tmp0
+	sha256_4_rounds_high	msg3,tmp0,tmp1
+
+	/* rounds 60-63 */
+	mov		l0_tmp2_v.16b,l0_abcd_v.16b
+	sha256h		l0_abcd_q,l0_efgh_q,l0_tmp1_v.4s
+	sha256h2	l0_efgh_q,l0_tmp2_q,l0_tmp1_v.4s
+
+	mov		l1_tmp2_v.16b,l1_abcd_v.16b
+	sha256h		l1_abcd_q,l1_efgh_q,l1_tmp1_v.4s
+	sha256h2	l1_efgh_q,l1_tmp2_q,l1_tmp1_v.4s
+
+
+
+	add     l0_abcd_v.4s,l0_abcd_v.4s,l0_abcd_saved_v.4s
+	add     l0_efgh_v.4s,l0_efgh_v.4s,l0_efgh_saved_v.4s
+	add     l1_abcd_v.4s,l1_abcd_v.4s,l1_abcd_saved_v.4s
+	add     l1_efgh_v.4s,l1_efgh_v.4s,l1_efgh_saved_v.4s
+
+
+	bgt	start_loop
+	str	l0_abcd_q,	[l0_job, 64]
+	str	l0_efgh_q, 	[l0_job, 80]
+	str	l1_abcd_q,	[l1_job, 64]
+	str	l1_efgh_q, 	[l1_job, 80]
+
+	ldp 	d10,d11,[sp,16]
+	ldp 	d12,d13,[sp,32]
+	ldp 	d14,d15,[sp,48]
+	ldp     d8, d9, [sp], 192
+	ret
+
+	.size	sha256_mb_ce_x2, .-sha256_mb_ce_x2
+	.section	.rol0_data.cst16,"aM",@progbits,16
+	.align	4
+KEY:
+	.word 0x428A2F98
+	.word 0x71374491
+	.word 0xB5C0FBCF
+	.word 0xE9B5DBA5
+	.word 0x3956C25B
+	.word 0x59F111F1
+	.word 0x923F82A4
+	.word 0xAB1C5ED5
+	.word 0xD807AA98
+	.word 0x12835B01
+	.word 0x243185BE
+	.word 0x550C7DC3
+	.word 0x72BE5D74
+	.word 0x80DEB1FE
+	.word 0x9BDC06A7
+	.word 0xC19BF174
+	.word 0xE49B69C1
+	.word 0xEFBE4786
+	.word 0x0FC19DC6
+	.word 0x240CA1CC
+	.word 0x2DE92C6F
+	.word 0x4A7484AA
+	.word 0x5CB0A9DC
+	.word 0x76F988DA
+	.word 0x983E5152
+	.word 0xA831C66D
+	.word 0xB00327C8
+	.word 0xBF597FC7
+	.word 0xC6E00BF3
+	.word 0xD5A79147
+	.word 0x06CA6351
+	.word 0x14292967
+	.word 0x27B70A85
+	.word 0x2E1B2138
+	.word 0x4D2C6DFC
+	.word 0x53380D13
+	.word 0x650A7354
+	.word 0x766A0ABB
+	.word 0x81C2C92E
+	.word 0x92722C85
+	.word 0xA2BFE8A1
+	.word 0xA81A664B
+	.word 0xC24B8B70
+	.word 0xC76C51A3
+	.word 0xD192E819
+	.word 0xD6990624
+	.word 0xF40E3585
+	.word 0x106AA070
+	.word 0x19A4C116
+	.word 0x1E376C08
+	.word 0x2748774C
+	.word 0x34B0BCB5
+	.word 0x391C0CB3
+	.word 0x4ED8AA4A
+	.word 0x5B9CCA4F
+	.word 0x682E6FF3
+	.word 0x748F82EE
+	.word 0x78A5636F
+	.word 0x84C87814
+	.word 0x8CC70208
+	.word 0x90BEFFFA
+	.word 0xA4506CEB
+	.word 0xBEF9A3F7
+	.word 0xC67178F2

--- a/sha256_mb/aarch64/sha256_mb_x3_ce.S
+++ b/sha256_mb/aarch64/sha256_mb_x3_ce.S
@@ -1,0 +1,342 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+	.arch armv8-a+crypto
+	.text
+	.align	2
+	.p2align 3,,7
+
+/*
+Macros
+*/
+
+.macro	declare_var_vector_reg name:req,reg:req
+	\name\()_q	.req	q\reg
+	\name\()_v	.req	v\reg
+	\name\()_s	.req	s\reg
+.endm
+/**
+maros for round 48-63
+*/
+.macro sha256_4_rounds_high msg:req,tmp0:req,tmp1:req
+	ldr		key_q , [tmp]
+	mov		l0_tmp2_v.16b,l0_abcd_v.16b
+	mov		l1_tmp2_v.16b,l1_abcd_v.16b
+	mov		l2_tmp2_v.16b,l2_abcd_v.16b
+	add		tmp,tmp,16
+	add		l0_\tmp1\()_v.4s,l0_\msg\()_v.4s,key_v.4s
+	add		l1_\tmp1\()_v.4s,l1_\msg\()_v.4s,key_v.4s
+	add		l2_\tmp1\()_v.4s,l2_\msg\()_v.4s,key_v.4s
+	sha256h		l0_abcd_q,l0_efgh_q,l0_\tmp0\()_v.4s
+	sha256h		l1_abcd_q,l1_efgh_q,l1_\tmp0\()_v.4s
+	sha256h		l2_abcd_q,l2_efgh_q,l2_\tmp0\()_v.4s
+	sha256h2	l0_efgh_q,l0_tmp2_q,l0_\tmp0\()_v.4s
+	sha256h2	l1_efgh_q,l1_tmp2_q,l1_\tmp0\()_v.4s
+	sha256h2	l2_efgh_q,l2_tmp2_q,l2_\tmp0\()_v.4s
+
+.endm
+/**
+maros for round 0-47
+*/
+.macro sha256_4_rounds_low msg0:req,msg1:req,msg2:req,msg3:req,tmp0:req,tmp1:req
+	sha256su0		l0_\msg0\()_v.4s,l0_\msg1\()_v.4s
+	sha256su0		l1_\msg0\()_v.4s,l1_\msg1\()_v.4s
+	sha256su0		l2_\msg0\()_v.4s,l2_\msg1\()_v.4s
+	sha256_4_rounds_high	\msg1,\tmp0,\tmp1
+	sha256su1		l0_\msg0\()_v.4s,l0_\msg2\()_v.4s,l0_\msg3\()_v.4s
+	sha256su1		l1_\msg0\()_v.4s,l1_\msg2\()_v.4s,l1_\msg3\()_v.4s
+	sha256su1		l2_\msg0\()_v.4s,l2_\msg2\()_v.4s,l2_\msg3\()_v.4s
+.endm
+
+
+/*
+Variable list
+*/
+
+	declare_var_vector_reg	key,31
+
+
+/*
+digest variables
+*/
+	declare_var_vector_reg	l0_abcd,0
+	declare_var_vector_reg	l0_efgh,1
+	declare_var_vector_reg	l1_abcd,2
+	declare_var_vector_reg	l1_efgh,3
+	declare_var_vector_reg	l2_abcd,4
+	declare_var_vector_reg	l2_efgh,5
+	declare_var_vector_reg	l1_abcd_saved,16
+	declare_var_vector_reg	l1_efgh_saved,17
+	declare_var_vector_reg	l0_abcd_saved,20
+	declare_var_vector_reg	l0_efgh_saved,21
+	declare_var_vector_reg	l2_abcd_saved,24
+	declare_var_vector_reg	l2_efgh_saved,25
+/*
+Temporay variables
+*/
+	declare_var_vector_reg	l0_tmp0,6
+	declare_var_vector_reg	l0_tmp1,7
+	declare_var_vector_reg	l0_tmp2,8
+	declare_var_vector_reg	l1_tmp0,9
+	declare_var_vector_reg	l1_tmp1,10
+	declare_var_vector_reg	l1_tmp2,11
+	declare_var_vector_reg	l2_tmp0,12
+	declare_var_vector_reg	l2_tmp1,13
+	declare_var_vector_reg	l2_tmp2,14
+/*
+Message variables
+*/
+	declare_var_vector_reg	l0_msg0,16
+	declare_var_vector_reg	l0_msg1,17
+	declare_var_vector_reg	l0_msg2,18
+	declare_var_vector_reg	l0_msg3,19
+	declare_var_vector_reg	l1_msg0,20
+	declare_var_vector_reg	l1_msg1,21
+	declare_var_vector_reg	l1_msg2,22
+	declare_var_vector_reg	l1_msg3,23
+	declare_var_vector_reg	l2_msg0,24
+	declare_var_vector_reg	l2_msg1,25
+	declare_var_vector_reg	l2_msg2,26
+	declare_var_vector_reg	l2_msg3,27
+
+
+
+/*
+	void sha256_mb_ce_x3(SHA256_JOB *, SHA256_JOB *, SHA256_JOB *, int);
+*/
+/*
+Arguements list
+*/
+	l0_job 	.req	x0
+	l1_job 	.req	x1
+	l2_job 	.req	x2
+	len	.req	w3
+	l0_data	.req	x4
+	l1_data	.req	x5
+	l2_data	.req	x6
+	tmp	.req	x7
+	.global	sha256_mb_ce_x3
+	.type	sha256_mb_ce_x3, %function
+sha256_mb_ce_x3:
+	//push d8~d15
+	stp 	d8,d9,[sp,-192]!
+	stp 	d10,d11,[sp,16]
+	stp 	d12,d13,[sp,32]
+	stp 	d14,d15,[sp,48]
+	ldr	l0_data, [l0_job]
+	ldr	l0_abcd_q, [l0_job, 64]
+	ldr	l0_efgh_q, [l0_job, 80]
+	ldr	l1_data,   [l1_job]
+	ldr	l1_abcd_q, [l1_job, 64]
+	ldr	l1_efgh_q, [l1_job, 80]
+	ldr	l2_data,   [l2_job]
+	ldr	l2_abcd_q, [l2_job, 64]
+	ldr	l2_efgh_q, [l2_job, 80]
+
+
+
+start_loop:
+
+	//load key addr
+	adr	tmp, KEY
+	//load msgs
+	ld1	{l0_msg0_v.4s-l0_msg3_v.4s},[l0_data]
+	ld1	{l1_msg0_v.4s-l1_msg3_v.4s},[l1_data]
+	ld1	{l2_msg0_v.4s-l2_msg3_v.4s},[l2_data]
+	ldr	key_q,[tmp]
+	add	tmp,tmp,16
+	//adjust loop parameter
+	add	l0_data,l0_data,64
+	add	l1_data,l1_data,64
+	add	l2_data,l2_data,64
+	sub	len, len, #1
+	cmp	len, 0
+/*
+	//backup digest
+	mov	l0_abcd_saved_v.16b,l0_abcd_v.16b
+	mov	l0_efgh_saved_v.16b,l0_efgh_v.16b
+	mov	l1_abcd_saved_v.16b,l1_abcd_v.16b
+	mov	l1_efgh_saved_v.16b,l1_efgh_v.16b
+	mov	l2_abcd_saved_v.16b,l2_abcd_v.16b
+	mov	l2_efgh_saved_v.16b,l2_efgh_v.16b
+*/
+
+	rev32	l0_msg0_v.16b,l0_msg0_v.16b
+	rev32	l0_msg1_v.16b,l0_msg1_v.16b
+	add	l0_tmp0_v.4s, l0_msg0_v.4s,key_v.4s
+	rev32	l0_msg2_v.16b,l0_msg2_v.16b
+	rev32	l0_msg3_v.16b,l0_msg3_v.16b
+
+	rev32	l1_msg0_v.16b,l1_msg0_v.16b
+	rev32	l1_msg1_v.16b,l1_msg1_v.16b
+	add	l1_tmp0_v.4s, l1_msg0_v.4s,key_v.4s
+	rev32	l1_msg2_v.16b,l1_msg2_v.16b
+	rev32	l1_msg3_v.16b,l1_msg3_v.16b
+
+	rev32	l2_msg0_v.16b,l2_msg0_v.16b
+	rev32	l2_msg1_v.16b,l2_msg1_v.16b
+	add	l2_tmp0_v.4s, l2_msg0_v.4s,key_v.4s
+	rev32	l2_msg2_v.16b,l2_msg2_v.16b
+	rev32	l2_msg3_v.16b,l2_msg3_v.16b
+
+
+
+	sha256_4_rounds_low	msg0,msg1,msg2,msg3,tmp0,tmp1    /* rounds 0-3 */
+	sha256_4_rounds_low	msg1,msg2,msg3,msg0,tmp1,tmp0
+	sha256_4_rounds_low	msg2,msg3,msg0,msg1,tmp0,tmp1
+	sha256_4_rounds_low	msg3,msg0,msg1,msg2,tmp1,tmp0
+
+	sha256_4_rounds_low	msg0,msg1,msg2,msg3,tmp0,tmp1    /* rounds 16-19 */
+	sha256_4_rounds_low	msg1,msg2,msg3,msg0,tmp1,tmp0
+	sha256_4_rounds_low	msg2,msg3,msg0,msg1,tmp0,tmp1
+	sha256_4_rounds_low	msg3,msg0,msg1,msg2,tmp1,tmp0
+	sha256_4_rounds_low	msg0,msg1,msg2,msg3,tmp0,tmp1    /* rounds 32-35 */
+	sha256_4_rounds_low	msg1,msg2,msg3,msg0,tmp1,tmp0
+	sha256_4_rounds_low	msg2,msg3,msg0,msg1,tmp0,tmp1
+	sha256_4_rounds_low	msg3,msg0,msg1,msg2,tmp1,tmp0
+
+
+
+	sha256_4_rounds_high	msg1,tmp0,tmp1			/* rounds 48-51 */
+
+	/* msg0 msg1 is free , share with digest regs */
+	ldr	l0_abcd_saved_q, [l0_job, 64]
+	ldr	l1_abcd_saved_q, [l1_job, 64]
+	ldr	l2_abcd_saved_q, [l2_job, 64]
+	ldr	l0_efgh_saved_q, [l0_job, 80]
+	ldr	l1_efgh_saved_q, [l1_job, 80]
+	ldr	l2_efgh_saved_q, [l2_job, 80]
+
+	sha256_4_rounds_high	msg2,tmp1,tmp0
+	sha256_4_rounds_high	msg3,tmp0,tmp1
+
+	/* rounds 60-63 */
+	mov		l0_tmp2_v.16b,l0_abcd_v.16b
+	sha256h		l0_abcd_q,l0_efgh_q,l0_tmp1_v.4s
+	sha256h2	l0_efgh_q,l0_tmp2_q,l0_tmp1_v.4s
+
+	mov		l1_tmp2_v.16b,l1_abcd_v.16b
+	sha256h		l1_abcd_q,l1_efgh_q,l1_tmp1_v.4s
+	sha256h2	l1_efgh_q,l1_tmp2_q,l1_tmp1_v.4s
+
+	mov		l2_tmp2_v.16b,l2_abcd_v.16b
+	sha256h		l2_abcd_q,l2_efgh_q,l2_tmp1_v.4s
+	sha256h2	l2_efgh_q,l2_tmp2_q,l2_tmp1_v.4s
+
+	/* combine state */
+	add     l0_abcd_v.4s,l0_abcd_v.4s,l0_abcd_saved_v.4s
+	add     l0_efgh_v.4s,l0_efgh_v.4s,l0_efgh_saved_v.4s
+	add     l1_abcd_v.4s,l1_abcd_v.4s,l1_abcd_saved_v.4s
+	add     l1_efgh_v.4s,l1_efgh_v.4s,l1_efgh_saved_v.4s
+	add     l2_abcd_v.4s,l2_abcd_v.4s,l2_abcd_saved_v.4s
+	add     l2_efgh_v.4s,l2_efgh_v.4s,l2_efgh_saved_v.4s
+
+	str	l0_abcd_q,	[l0_job, 64]
+	str	l0_efgh_q, 	[l0_job, 80]
+	str	l1_abcd_q,	[l1_job, 64]
+	str	l1_efgh_q, 	[l1_job, 80]
+	str	l2_abcd_q,	[l2_job, 64]
+	str	l2_efgh_q, 	[l2_job, 80]
+
+	bgt	start_loop
+
+
+	ldp 	d10,d11,[sp,16]
+	ldp 	d12,d13,[sp,32]
+	ldp 	d14,d15,[sp,48]
+	ldp     d8, d9, [sp], 192
+	ret
+
+	.size	sha256_mb_ce_x3, .-sha256_mb_ce_x3
+	.section	.rol0_data.cst16,"aM",@progbits,16
+	.align	4
+KEY:
+	.word 0x428A2F98
+	.word 0x71374491
+	.word 0xB5C0FBCF
+	.word 0xE9B5DBA5
+	.word 0x3956C25B
+	.word 0x59F111F1
+	.word 0x923F82A4
+	.word 0xAB1C5ED5
+	.word 0xD807AA98
+	.word 0x12835B01
+	.word 0x243185BE
+	.word 0x550C7DC3
+	.word 0x72BE5D74
+	.word 0x80DEB1FE
+	.word 0x9BDC06A7
+	.word 0xC19BF174
+	.word 0xE49B69C1
+	.word 0xEFBE4786
+	.word 0x0FC19DC6
+	.word 0x240CA1CC
+	.word 0x2DE92C6F
+	.word 0x4A7484AA
+	.word 0x5CB0A9DC
+	.word 0x76F988DA
+	.word 0x983E5152
+	.word 0xA831C66D
+	.word 0xB00327C8
+	.word 0xBF597FC7
+	.word 0xC6E00BF3
+	.word 0xD5A79147
+	.word 0x06CA6351
+	.word 0x14292967
+	.word 0x27B70A85
+	.word 0x2E1B2138
+	.word 0x4D2C6DFC
+	.word 0x53380D13
+	.word 0x650A7354
+	.word 0x766A0ABB
+	.word 0x81C2C92E
+	.word 0x92722C85
+	.word 0xA2BFE8A1
+	.word 0xA81A664B
+	.word 0xC24B8B70
+	.word 0xC76C51A3
+	.word 0xD192E819
+	.word 0xD6990624
+	.word 0xF40E3585
+	.word 0x106AA070
+	.word 0x19A4C116
+	.word 0x1E376C08
+	.word 0x2748774C
+	.word 0x34B0BCB5
+	.word 0x391C0CB3
+	.word 0x4ED8AA4A
+	.word 0x5B9CCA4F
+	.word 0x682E6FF3
+	.word 0x748F82EE
+	.word 0x78A5636F
+	.word 0x84C87814
+	.word 0x8CC70208
+	.word 0x90BEFFFA
+	.word 0xA4506CEB
+	.word 0xBEF9A3F7
+	.word 0xC67178F2

--- a/sha256_mb/aarch64/sha256_mb_x4_ce.S
+++ b/sha256_mb/aarch64/sha256_mb_x4_ce.S
@@ -1,0 +1,380 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+	.arch armv8-a+crypto
+	.text
+	.align	2
+	.p2align 3,,7
+
+/*
+Macros
+*/
+
+.macro	declare_var_vector_reg name:req,reg:req
+	\name\()_q	.req	q\reg
+	\name\()_v	.req	v\reg
+	\name\()_s	.req	s\reg
+.endm
+/**
+maros for round 48-63
+tmp0 : in
+tmp1 : out
+*/
+.macro sha256_4_rounds_high msg:req,tmp0:req
+	ldr		key_q , [tmp]
+	mov		tmp0_v.16b,l0_\tmp0\()_v.16b
+	mov		tmp1_v.16b,l1_\tmp0\()_v.16b
+	add		l0_\tmp0\()_v.4s,l0_\msg\()_v.4s,key_v.4s
+	add		l1_\tmp0\()_v.4s,l1_\msg\()_v.4s,key_v.4s
+	mov		tmp2_v.16b,l0_abcd_v.16b
+	mov		tmp3_v.16b,l1_abcd_v.16b
+	sha256h		l0_abcd_q,l0_efgh_q,tmp0_v.4s
+	sha256h		l1_abcd_q,l1_efgh_q,tmp1_v.4s
+	sha256h2	l0_efgh_q,tmp2_q,tmp0_v.4s
+	sha256h2	l1_efgh_q,tmp3_q,tmp1_v.4s
+
+	ldr		key_q , [tmp]
+	mov		tmp0_v.16b,l2_\tmp0\()_v.16b
+	mov		tmp1_v.16b,l3_\tmp0\()_v.16b
+	add		tmp,tmp,16
+	add		l2_\tmp0\()_v.4s,l2_\msg\()_v.4s,key_v.4s
+	add		l3_\tmp0\()_v.4s,l3_\msg\()_v.4s,key_v.4s
+	mov		tmp2_v.16b,l2_abcd_v.16b
+	mov		tmp3_v.16b,l3_abcd_v.16b
+	sha256h		l2_abcd_q,l2_efgh_q,tmp0_v.4s
+	sha256h		l3_abcd_q,l3_efgh_q,tmp1_v.4s
+	sha256h2	l2_efgh_q,tmp2_q,tmp0_v.4s
+	sha256h2	l3_efgh_q,tmp3_q,tmp1_v.4s
+
+
+.endm
+/**
+maros for round 0-47
+*/
+.macro sha256_4_rounds_low msg0:req,msg1:req,msg2:req,msg3:req,tmp0:req
+	sha256su0		l0_\msg0\()_v.4s,l0_\msg1\()_v.4s
+	sha256su0		l1_\msg0\()_v.4s,l1_\msg1\()_v.4s
+	sha256su0		l2_\msg0\()_v.4s,l2_\msg1\()_v.4s
+	sha256su0		l3_\msg0\()_v.4s,l3_\msg1\()_v.4s
+	sha256_4_rounds_high	\msg1,\tmp0
+	sha256su1		l0_\msg0\()_v.4s,l0_\msg2\()_v.4s,l0_\msg3\()_v.4s
+	sha256su1		l1_\msg0\()_v.4s,l1_\msg2\()_v.4s,l1_\msg3\()_v.4s
+	sha256su1		l2_\msg0\()_v.4s,l2_\msg2\()_v.4s,l2_\msg3\()_v.4s
+	sha256su1		l3_\msg0\()_v.4s,l3_\msg2\()_v.4s,l3_\msg3\()_v.4s
+.endm
+
+
+/*
+Variable list
+*/
+
+	declare_var_vector_reg	key,15
+
+
+/*
+digest variables
+*/
+	declare_var_vector_reg	l0_abcd,0
+	declare_var_vector_reg	l0_efgh,1
+	declare_var_vector_reg	l1_abcd,2
+	declare_var_vector_reg	l1_efgh,3
+	declare_var_vector_reg	l2_abcd,4
+	declare_var_vector_reg	l2_efgh,5
+	declare_var_vector_reg	l3_abcd,6
+	declare_var_vector_reg	l3_efgh,7
+	declare_var_vector_reg	l1_abcd_saved,16
+	declare_var_vector_reg	l1_efgh_saved,17
+	declare_var_vector_reg	l0_abcd_saved,20
+	declare_var_vector_reg	l0_efgh_saved,21
+	declare_var_vector_reg	l2_abcd_saved,24
+	declare_var_vector_reg	l2_efgh_saved,25
+	declare_var_vector_reg	l3_abcd_saved,28
+	declare_var_vector_reg	l3_efgh_saved,29
+/*
+Temporay variables
+*/
+	declare_var_vector_reg	l0_tmp0,8
+	declare_var_vector_reg	l1_tmp0,9
+	declare_var_vector_reg	l2_tmp0,10
+	declare_var_vector_reg	l3_tmp0,11
+
+	declare_var_vector_reg	tmp0,12
+	declare_var_vector_reg	tmp1,13
+	declare_var_vector_reg	tmp2,14
+	declare_var_vector_reg	tmp3,15
+
+/*
+Message variables
+*/
+	declare_var_vector_reg	l0_msg0,16
+	declare_var_vector_reg	l0_msg1,17
+	declare_var_vector_reg	l0_msg2,18
+	declare_var_vector_reg	l0_msg3,19
+	declare_var_vector_reg	l1_msg0,20
+	declare_var_vector_reg	l1_msg1,21
+	declare_var_vector_reg	l1_msg2,22
+	declare_var_vector_reg	l1_msg3,23
+	declare_var_vector_reg	l2_msg0,24
+	declare_var_vector_reg	l2_msg1,25
+	declare_var_vector_reg	l2_msg2,26
+	declare_var_vector_reg	l2_msg3,27
+	declare_var_vector_reg	l3_msg0,28
+	declare_var_vector_reg	l3_msg1,29
+	declare_var_vector_reg	l3_msg2,30
+	declare_var_vector_reg	l3_msg3,31
+
+
+
+/*
+	void sha256_mb_ce_x4(SHA256_JOB *, SHA256_JOB *, SHA256_JOB *, SHA256_JOB *, int);
+*/
+/*
+Arguements list
+*/
+	l0_job 	.req	x0
+	l1_job 	.req	x1
+	l2_job 	.req	x2
+	l3_job 	.req	x3
+	len	.req	w4
+	l0_data	.req	x5
+	l1_data	.req	x6
+	l2_data	.req	x7
+	l3_data	.req	x8
+	tmp	.req	x9
+	.global	sha256_mb_ce_x4
+	.type	sha256_mb_ce_x4, %function
+sha256_mb_ce_x4:
+	//push d8~d15
+	stp 	d8,d9,[sp,-192]!
+	stp 	d10,d11,[sp,16]
+	stp 	d12,d13,[sp,32]
+	stp 	d14,d15,[sp,48]
+	ldr	l0_data, [l0_job]
+	ldr	l0_abcd_q, [l0_job, 64]
+	ldr	l0_efgh_q, [l0_job, 80]
+	ldr	l1_data,   [l1_job]
+	ldr	l1_abcd_q, [l1_job, 64]
+	ldr	l1_efgh_q, [l1_job, 80]
+	ldr	l2_data,   [l2_job]
+	ldr	l2_abcd_q, [l2_job, 64]
+	ldr	l2_efgh_q, [l2_job, 80]
+	ldr	l3_data,   [l3_job]
+	ldr	l3_abcd_q, [l3_job, 64]
+	ldr	l3_efgh_q, [l3_job, 80]
+
+
+
+start_loop:
+
+	//load key addr
+	adr	tmp, KEY
+	//load msgs
+	ld1	{l0_msg0_v.4s-l0_msg3_v.4s},[l0_data]
+	ld1	{l1_msg0_v.4s-l1_msg3_v.4s},[l1_data]
+	ld1	{l2_msg0_v.4s-l2_msg3_v.4s},[l2_data]
+	ld1	{l3_msg0_v.4s-l3_msg3_v.4s},[l3_data]
+	ldr	key_q,[tmp]
+	add	tmp,tmp,16
+	//adjust loop parameter
+	add	l0_data,l0_data,64
+	add	l1_data,l1_data,64
+	add	l2_data,l2_data,64
+	add	l3_data,l3_data,64
+	sub	len, len, #1
+	cmp	len, 0
+
+
+	rev32	l0_msg0_v.16b,l0_msg0_v.16b
+	rev32	l0_msg1_v.16b,l0_msg1_v.16b
+	add	l0_tmp0_v.4s, l0_msg0_v.4s,key_v.4s
+	rev32	l0_msg2_v.16b,l0_msg2_v.16b
+	rev32	l0_msg3_v.16b,l0_msg3_v.16b
+
+	rev32	l1_msg0_v.16b,l1_msg0_v.16b
+	rev32	l1_msg1_v.16b,l1_msg1_v.16b
+	add	l1_tmp0_v.4s, l1_msg0_v.4s,key_v.4s
+	rev32	l1_msg2_v.16b,l1_msg2_v.16b
+	rev32	l1_msg3_v.16b,l1_msg3_v.16b
+
+	rev32	l2_msg0_v.16b,l2_msg0_v.16b
+	rev32	l2_msg1_v.16b,l2_msg1_v.16b
+	add	l2_tmp0_v.4s, l2_msg0_v.4s,key_v.4s
+	rev32	l2_msg2_v.16b,l2_msg2_v.16b
+	rev32	l2_msg3_v.16b,l2_msg3_v.16b
+
+	rev32	l3_msg0_v.16b,l3_msg0_v.16b
+	rev32	l3_msg1_v.16b,l3_msg1_v.16b
+	add	l3_tmp0_v.4s, l3_msg0_v.4s,key_v.4s
+	rev32	l3_msg2_v.16b,l3_msg2_v.16b
+	rev32	l3_msg3_v.16b,l3_msg3_v.16b
+
+
+
+	sha256_4_rounds_low	msg0,msg1,msg2,msg3,tmp0    /* rounds 0-3 */
+	sha256_4_rounds_low	msg1,msg2,msg3,msg0,tmp0
+	sha256_4_rounds_low	msg2,msg3,msg0,msg1,tmp0
+	sha256_4_rounds_low	msg3,msg0,msg1,msg2,tmp0
+	sha256_4_rounds_low	msg0,msg1,msg2,msg3,tmp0    /* rounds 16-19 */
+	sha256_4_rounds_low	msg1,msg2,msg3,msg0,tmp0
+	sha256_4_rounds_low	msg2,msg3,msg0,msg1,tmp0
+	sha256_4_rounds_low	msg3,msg0,msg1,msg2,tmp0
+	sha256_4_rounds_low	msg0,msg1,msg2,msg3,tmp0    /* rounds 32-35 */
+	sha256_4_rounds_low	msg1,msg2,msg3,msg0,tmp0
+	sha256_4_rounds_low	msg2,msg3,msg0,msg1,tmp0
+	sha256_4_rounds_low	msg3,msg0,msg1,msg2,tmp0
+
+
+
+	sha256_4_rounds_high	msg1,tmp0			/* rounds 48-51 */
+
+	/* msg0 msg1 is free , share with digest regs */
+	ldr	l0_abcd_saved_q, [l0_job, 64]
+	ldr	l1_abcd_saved_q, [l1_job, 64]
+	ldr	l2_abcd_saved_q, [l2_job, 64]
+	ldr	l3_abcd_saved_q, [l3_job, 64]
+	ldr	l0_efgh_saved_q, [l0_job, 80]
+	ldr	l1_efgh_saved_q, [l1_job, 80]
+	ldr	l2_efgh_saved_q, [l2_job, 80]
+	ldr	l3_efgh_saved_q, [l3_job, 80]
+
+	sha256_4_rounds_high	msg2,tmp0
+	sha256_4_rounds_high	msg3,tmp0
+
+	/* rounds 60-63 */
+	mov		tmp2_v.16b,l0_abcd_v.16b
+	sha256h		l0_abcd_q,l0_efgh_q,l0_tmp0_v.4s
+	sha256h2	l0_efgh_q,tmp2_q,l0_tmp0_v.4s
+
+	mov		tmp2_v.16b,l1_abcd_v.16b
+	sha256h		l1_abcd_q,l1_efgh_q,l1_tmp0_v.4s
+	sha256h2	l1_efgh_q,tmp2_q,l1_tmp0_v.4s
+
+	mov		tmp2_v.16b,l2_abcd_v.16b
+	sha256h		l2_abcd_q,l2_efgh_q,l2_tmp0_v.4s
+	sha256h2	l2_efgh_q,tmp2_q,l2_tmp0_v.4s
+
+	mov		tmp2_v.16b,l3_abcd_v.16b
+	sha256h		l3_abcd_q,l3_efgh_q,l3_tmp0_v.4s
+	sha256h2	l3_efgh_q,tmp2_q,l3_tmp0_v.4s
+
+	/* combine state */
+	add     l0_abcd_v.4s,l0_abcd_v.4s,l0_abcd_saved_v.4s
+	add     l0_efgh_v.4s,l0_efgh_v.4s,l0_efgh_saved_v.4s
+	add     l1_abcd_v.4s,l1_abcd_v.4s,l1_abcd_saved_v.4s
+	add     l1_efgh_v.4s,l1_efgh_v.4s,l1_efgh_saved_v.4s
+	add     l2_abcd_v.4s,l2_abcd_v.4s,l2_abcd_saved_v.4s
+	add     l2_efgh_v.4s,l2_efgh_v.4s,l2_efgh_saved_v.4s
+	add     l3_abcd_v.4s,l3_abcd_v.4s,l3_abcd_saved_v.4s
+	add     l3_efgh_v.4s,l3_efgh_v.4s,l3_efgh_saved_v.4s
+
+	str	l0_abcd_q,	[l0_job, 64]
+	str	l0_efgh_q, 	[l0_job, 80]
+	str	l1_abcd_q,	[l1_job, 64]
+	str	l1_efgh_q, 	[l1_job, 80]
+	str	l2_abcd_q,	[l2_job, 64]
+	str	l2_efgh_q, 	[l2_job, 80]
+	str	l3_abcd_q,	[l3_job, 64]
+	str	l3_efgh_q, 	[l3_job, 80]
+
+	bgt	start_loop
+
+
+	ldp 	d10,d11,[sp,16]
+	ldp 	d12,d13,[sp,32]
+	ldp 	d14,d15,[sp,48]
+	ldp     d8, d9, [sp], 192
+	ret
+
+	.size	sha256_mb_ce_x4, .-sha256_mb_ce_x4
+	.section	.rol0_data.cst16,"aM",@progbits,16
+	.align	4
+KEY:
+	.word 0x428A2F98
+	.word 0x71374491
+	.word 0xB5C0FBCF
+	.word 0xE9B5DBA5
+	.word 0x3956C25B
+	.word 0x59F111F1
+	.word 0x923F82A4
+	.word 0xAB1C5ED5
+	.word 0xD807AA98
+	.word 0x12835B01
+	.word 0x243185BE
+	.word 0x550C7DC3
+	.word 0x72BE5D74
+	.word 0x80DEB1FE
+	.word 0x9BDC06A7
+	.word 0xC19BF174
+	.word 0xE49B69C1
+	.word 0xEFBE4786
+	.word 0x0FC19DC6
+	.word 0x240CA1CC
+	.word 0x2DE92C6F
+	.word 0x4A7484AA
+	.word 0x5CB0A9DC
+	.word 0x76F988DA
+	.word 0x983E5152
+	.word 0xA831C66D
+	.word 0xB00327C8
+	.word 0xBF597FC7
+	.word 0xC6E00BF3
+	.word 0xD5A79147
+	.word 0x06CA6351
+	.word 0x14292967
+	.word 0x27B70A85
+	.word 0x2E1B2138
+	.word 0x4D2C6DFC
+	.word 0x53380D13
+	.word 0x650A7354
+	.word 0x766A0ABB
+	.word 0x81C2C92E
+	.word 0x92722C85
+	.word 0xA2BFE8A1
+	.word 0xA81A664B
+	.word 0xC24B8B70
+	.word 0xC76C51A3
+	.word 0xD192E819
+	.word 0xD6990624
+	.word 0xF40E3585
+	.word 0x106AA070
+	.word 0x19A4C116
+	.word 0x1E376C08
+	.word 0x2748774C
+	.word 0x34B0BCB5
+	.word 0x391C0CB3
+	.word 0x4ED8AA4A
+	.word 0x5B9CCA4F
+	.word 0x682E6FF3
+	.word 0x748F82EE
+	.word 0x78A5636F
+	.word 0x84C87814
+	.word 0x8CC70208
+	.word 0x90BEFFFA
+	.word 0xA4506CEB
+	.word 0xBEF9A3F7
+	.word 0xC67178F2

--- a/sha256_mb/sha256_ctx_base_aliases.c
+++ b/sha256_mb/sha256_ctx_base_aliases.c
@@ -1,0 +1,54 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stdint.h>
+#include <string.h>
+#include "sha256_mb.h"
+#include "memcpy_inline.h"
+
+extern void sha256_ctx_mgr_init_base(SHA256_HASH_CTX_MGR * mgr);
+extern SHA256_HASH_CTX *sha256_ctx_mgr_submit_base(SHA256_HASH_CTX_MGR * mgr,
+						   SHA256_HASH_CTX * ctx, const void *buffer,
+						   uint32_t len, HASH_CTX_FLAG flags);
+extern SHA256_HASH_CTX *sha256_ctx_mgr_flush_base(SHA256_HASH_CTX_MGR * mgr);
+
+void sha256_ctx_mgr_init(SHA256_HASH_CTX_MGR * mgr)
+{
+	return sha256_ctx_mgr_init_base(mgr);
+}
+
+SHA256_HASH_CTX *sha256_ctx_mgr_submit(SHA256_HASH_CTX_MGR * mgr, SHA256_HASH_CTX * ctx,
+				       const void *buffer, uint32_t len, HASH_CTX_FLAG flags)
+{
+	return sha256_ctx_mgr_submit_base(mgr, ctx, buffer, len, flags);
+}
+
+SHA256_HASH_CTX *sha256_ctx_mgr_flush(SHA256_HASH_CTX_MGR * mgr)
+{
+	return sha256_ctx_mgr_flush_base(mgr);
+}

--- a/sha512_mb/Makefile.am
+++ b/sha512_mb/Makefile.am
@@ -61,7 +61,8 @@ lsrc_x86_64 += 	sha512_mb/sha512_ctx_avx512.c \
 
 lsrc_x86_32 += 	$(lsrc_x86_64)
 
-lsrc_aarch64 += sha512_mb/sha512_ctx_base.c
+lsrc_aarch64 += sha512_mb/sha512_ctx_base.c	\
+		sha512_mb/sha512_ctx_base_aliases.c
 
 src_include += -I $(srcdir)/sha512_mb
 

--- a/sha512_mb/Makefile.am
+++ b/sha512_mb/Makefile.am
@@ -61,8 +61,13 @@ lsrc_x86_64 += 	sha512_mb/sha512_ctx_avx512.c \
 
 lsrc_x86_32 += 	$(lsrc_x86_64)
 
-lsrc_aarch64 += sha512_mb/sha512_ctx_base.c	\
-		sha512_mb/sha512_ctx_base_aliases.c
+lsrc_aarch64 += sha512_mb/sha512_ctx_base.c			\
+		sha512_mb/aarch64/sha512_mb_multibinary.S 	\
+		sha512_mb/aarch64/sha512_mb_dispatch_init.c  \
+		sha512_mb/aarch64/sha512_ctx_ce.c			\
+		sha512_mb/aarch64/sha512_mb_mgr_ce.c	\
+		sha512_mb/aarch64/sha512_mb_x1_ce.S	\
+		sha512_mb/aarch64/sha512_mb_x2_ce.S
 
 src_include += -I $(srcdir)/sha512_mb
 

--- a/sha512_mb/aarch64/sha512_ctx_ce.c
+++ b/sha512_mb/aarch64/sha512_ctx_ce.c
@@ -1,0 +1,255 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdint.h>
+#include <string.h>
+#include "sha512_mb.h"
+#include "memcpy_inline.h"
+
+void sha512_mb_mgr_init_ce(SHA512_MB_JOB_MGR * state);
+SHA512_JOB *sha512_mb_mgr_submit_ce(SHA512_MB_JOB_MGR * state, SHA512_JOB * job);
+SHA512_JOB *sha512_mb_mgr_flush_ce(SHA512_MB_JOB_MGR * state);
+static inline void hash_init_digest(SHA512_WORD_T * digest);
+static inline uint32_t hash_pad(uint8_t padblock[SHA512_BLOCK_SIZE * 2], uint64_t total_len);
+static SHA512_HASH_CTX *sha512_ctx_mgr_resubmit(SHA512_HASH_CTX_MGR * mgr,
+						SHA512_HASH_CTX * ctx);
+
+void sha512_ctx_mgr_init_ce(SHA512_HASH_CTX_MGR * mgr)
+{
+	sha512_mb_mgr_init_ce(&mgr->mgr);
+}
+
+SHA512_HASH_CTX *sha512_ctx_mgr_submit_ce(SHA512_HASH_CTX_MGR * mgr, SHA512_HASH_CTX * ctx,
+					  const void *buffer, uint32_t len,
+					  HASH_CTX_FLAG flags)
+{
+	if (flags & (~HASH_ENTIRE)) {
+		// User should not pass anything other than FIRST, UPDATE, or LAST
+		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
+	}
+
+	if (ctx->status & HASH_CTX_STS_PROCESSING) {
+		// Cannot submit to a currently processing job.
+		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
+	}
+
+	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
+		// Cannot update a finished job.
+		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
+	}
+
+	if (flags & HASH_FIRST) {
+		// Init digest
+		hash_init_digest(ctx->job.result_digest);
+
+		// Reset byte counter
+		ctx->total_length = 0;
+
+		// Clear extra blocks
+		ctx->partial_block_buffer_length = 0;
+	}
+	// If we made it here, there were no errors during this call to submit
+	ctx->error = HASH_CTX_ERROR_NONE;
+
+	// Store buffer ptr info from user
+	ctx->incoming_buffer = buffer;
+	ctx->incoming_buffer_length = len;
+
+	// Store the user's request flags and mark this ctx as currently being processed.
+	ctx->status = (flags & HASH_LAST) ?
+	    (HASH_CTX_STS) (HASH_CTX_STS_PROCESSING | HASH_CTX_STS_LAST) :
+	    HASH_CTX_STS_PROCESSING;
+
+	// Advance byte counter
+	ctx->total_length += len;
+
+	// If there is anything currently buffered in the extra blocks, append to it until it contains a whole block.
+	// Or if the user's buffer contains less than a whole block, append as much as possible to the extra block.
+	if ((ctx->partial_block_buffer_length) | (len < SHA512_BLOCK_SIZE)) {
+		// Compute how many bytes to copy from user buffer into extra block
+		uint32_t copy_len = SHA512_BLOCK_SIZE - ctx->partial_block_buffer_length;
+		if (len < copy_len)
+			copy_len = len;
+
+		if (copy_len) {
+			// Copy and update relevant pointers and counters
+			memcpy_fixedlen(&ctx->partial_block_buffer
+					[ctx->partial_block_buffer_length], buffer, copy_len);
+
+			ctx->partial_block_buffer_length += copy_len;
+			ctx->incoming_buffer = (const void *)((const char *)buffer + copy_len);
+			ctx->incoming_buffer_length = len - copy_len;
+		}
+		// The extra block should never contain more than 1 block here
+		assert(ctx->partial_block_buffer_length <= SHA512_BLOCK_SIZE);
+
+		// If the extra block buffer contains exactly 1 block, it can be hashed.
+		if (ctx->partial_block_buffer_length >= SHA512_BLOCK_SIZE) {
+			ctx->partial_block_buffer_length = 0;
+
+			ctx->job.buffer = ctx->partial_block_buffer;
+			ctx->job.len = 1;
+
+			ctx =
+			    (SHA512_HASH_CTX *) sha512_mb_mgr_submit_ce(&mgr->mgr, &ctx->job);
+		}
+	}
+
+	return sha512_ctx_mgr_resubmit(mgr, ctx);
+}
+
+SHA512_HASH_CTX *sha512_ctx_mgr_flush_ce(SHA512_HASH_CTX_MGR * mgr)
+{
+	SHA512_HASH_CTX *ctx;
+
+	while (1) {
+		ctx = (SHA512_HASH_CTX *) sha512_mb_mgr_flush_ce(&mgr->mgr);
+
+		// If flush returned 0, there are no more jobs in flight.
+		if (!ctx)
+			return NULL;
+
+		// If flush returned a job, verify that it is safe to return to the user.
+		// If it is not ready, resubmit the job to finish processing.
+		ctx = sha512_ctx_mgr_resubmit(mgr, ctx);
+
+		// If sha512_ctx_mgr_resubmit returned a job, it is ready to be returned.
+		if (ctx)
+			return ctx;
+
+		// Otherwise, all jobs currently being managed by the SHA512_HASH_CTX_MGR still need processing. Loop.
+	}
+}
+
+static SHA512_HASH_CTX *sha512_ctx_mgr_resubmit(SHA512_HASH_CTX_MGR * mgr,
+						SHA512_HASH_CTX * ctx)
+{
+	while (ctx) {
+
+		if (ctx->status & HASH_CTX_STS_COMPLETE) {
+			ctx->status = HASH_CTX_STS_COMPLETE;	// Clear PROCESSING bit
+			return ctx;
+		}
+		// If the extra blocks are empty, begin hashing what remains in the user's buffer.
+		if (ctx->partial_block_buffer_length == 0 && ctx->incoming_buffer_length) {
+			const void *buffer = ctx->incoming_buffer;
+			uint32_t len = ctx->incoming_buffer_length;
+
+			// Only entire blocks can be hashed. Copy remainder to extra blocks buffer.
+			uint32_t copy_len = len & (SHA512_BLOCK_SIZE - 1);
+
+			if (copy_len) {
+				len -= copy_len;
+				memcpy_fixedlen(ctx->partial_block_buffer,
+						((const char *)buffer + len), copy_len);
+				ctx->partial_block_buffer_length = copy_len;
+			}
+
+			ctx->incoming_buffer_length = 0;
+
+			// len should be a multiple of the block size now
+			assert((len % SHA512_BLOCK_SIZE) == 0);
+
+			// Set len to the number of blocks to be hashed in the user's buffer
+			len >>= SHA512_LOG2_BLOCK_SIZE;
+
+			if (len) {
+				ctx->job.buffer = (uint8_t *) buffer;
+				ctx->job.len = len;
+				ctx = (SHA512_HASH_CTX *) sha512_mb_mgr_submit_ce(&mgr->mgr,
+										  &ctx->job);
+				continue;
+			}
+		}
+		// If the extra blocks are not empty, then we are either on the last block(s)
+		// or we need more user input before continuing.
+		if (ctx->status & HASH_CTX_STS_LAST) {
+			uint8_t *buf = ctx->partial_block_buffer;
+			uint32_t n_extra_blocks = hash_pad(buf, ctx->total_length);
+
+			ctx->status =
+			    (HASH_CTX_STS) (HASH_CTX_STS_PROCESSING | HASH_CTX_STS_COMPLETE);
+			ctx->job.buffer = buf;
+			ctx->job.len = (uint32_t) n_extra_blocks;
+			ctx =
+			    (SHA512_HASH_CTX *) sha512_mb_mgr_submit_ce(&mgr->mgr, &ctx->job);
+			continue;
+		}
+
+		if (ctx)
+			ctx->status = HASH_CTX_STS_IDLE;
+		return ctx;
+	}
+
+	return NULL;
+}
+
+static inline void hash_init_digest(SHA512_WORD_T * digest)
+{
+	static const SHA512_WORD_T hash_initial_digest[SHA512_DIGEST_NWORDS] =
+	    { SHA512_INITIAL_DIGEST };
+	memcpy_fixedlen(digest, hash_initial_digest, sizeof(hash_initial_digest));
+}
+
+static inline uint32_t hash_pad(uint8_t padblock[SHA512_BLOCK_SIZE * 2], uint64_t total_len)
+{
+	uint32_t i = (uint32_t) (total_len & (SHA512_BLOCK_SIZE - 1));
+
+	memclr_fixedlen(&padblock[i], SHA512_BLOCK_SIZE);
+	padblock[i] = 0x80;
+
+	// Move i to the end of either 1st or 2nd extra block depending on length
+	i += ((SHA512_BLOCK_SIZE - 1) & (0 - (total_len + SHA512_PADLENGTHFIELD_SIZE + 1))) +
+	    1 + SHA512_PADLENGTHFIELD_SIZE;
+
+#if SHA512_PADLENGTHFIELD_SIZE == 16
+	*((uint64_t *) & padblock[i - 16]) = 0;
+#endif
+
+	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+
+	return i >> SHA512_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
+}
+
+struct slver {
+	uint16_t snum;
+	uint8_t ver;
+	uint8_t core;
+};
+struct slver sha512_ctx_mgr_init_ce_slver_02020142;
+struct slver sha512_ctx_mgr_init_ce_slver = { 0x0142, 0x02, 0x02 };
+
+struct slver sha512_ctx_mgr_submit_ce_slver_02020143;
+struct slver sha512_ctx_mgr_submit_ce_slver = { 0x0143, 0x02, 0x02 };
+
+struct slver sha512_ctx_mgr_flush_ce_slver_02020144;
+struct slver sha512_ctx_mgr_flush_ce_slver = { 0x0144, 0x02, 0x02 };

--- a/sha512_mb/aarch64/sha512_mb_dispatch_init.c
+++ b/sha512_mb/aarch64/sha512_mb_dispatch_init.c
@@ -1,0 +1,61 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stdint.h>
+#include <string.h>
+#include "sha512_mb.h"
+#include "memcpy_inline.h"
+
+extern void sha512_ctx_mgr_init_ce(SHA512_HASH_CTX_MGR * mgr);
+extern SHA512_HASH_CTX *sha512_ctx_mgr_submit_ce(SHA512_HASH_CTX_MGR * mgr,
+						 SHA512_HASH_CTX * ctx, const void *buffer,
+						 uint32_t len, HASH_CTX_FLAG flags);
+extern SHA512_HASH_CTX *sha512_ctx_mgr_flush_ce(SHA512_HASH_CTX_MGR * mgr);
+
+extern typeof(sha512_ctx_mgr_init_ce) * sha512_ctx_mgr_init_dispatched;
+void sha512_ctx_mgr_init_dispatch_init(SHA512_HASH_CTX_MGR * mgr)
+{
+	sha512_ctx_mgr_init_dispatched = sha512_ctx_mgr_init_ce;
+	return sha512_ctx_mgr_init_dispatched(mgr);
+}
+
+extern typeof(sha512_ctx_mgr_submit_ce) * sha512_ctx_mgr_submit_dispatched;
+SHA512_HASH_CTX *sha512_ctx_mgr_submit_dispatch_init(SHA512_HASH_CTX_MGR * mgr,
+						     SHA512_HASH_CTX * ctx, const void *buffer,
+						     uint32_t len, HASH_CTX_FLAG flags)
+{
+	sha512_ctx_mgr_submit_dispatched = sha512_ctx_mgr_submit_ce;
+	return sha512_ctx_mgr_submit_dispatched(mgr, ctx, buffer, len, flags);
+}
+
+extern typeof(sha512_ctx_mgr_flush_ce) * sha512_ctx_mgr_flush_dispatched;
+SHA512_HASH_CTX *sha512_ctx_mgr_flush_dispatch_init(SHA512_HASH_CTX_MGR * mgr)
+{
+	sha512_ctx_mgr_flush_dispatched = sha512_ctx_mgr_flush_ce;
+	return sha512_ctx_mgr_flush_dispatched(mgr);
+}

--- a/sha512_mb/aarch64/sha512_mb_mgr_ce.c
+++ b/sha512_mb/aarch64/sha512_mb_mgr_ce.c
@@ -1,0 +1,210 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stddef.h>
+#include <sha512_mb.h>
+#include <assert.h>
+
+#ifndef max
+#define max(a,b)            (((a) > (b)) ? (a) : (b))
+#endif
+
+#ifndef min
+#define min(a,b)            (((a) < (b)) ? (a) : (b))
+#endif
+#ifndef SHA512_MB_CE_MAX_LANES
+#define SHA512_MB_CE_MAX_LANES	2
+#endif
+
+#if SHA512_MB_CE_MAX_LANES >=2
+void sha512_mb_ce_x2(SHA512_JOB *, SHA512_JOB *, int);
+#endif
+void sha512_mb_ce_x1(SHA512_JOB *, int);
+
+#define LANE_IS_NOT_FINISHED(state,i)  	\
+	(((state->lens[i]&(~0xf))!=0) && state->ldata[i].job_in_lane!=NULL)
+#define LANE_IS_FINISHED(state,i)  	\
+	(((state->lens[i]&(~0xf))==0) && state->ldata[i].job_in_lane!=NULL)
+#define	LANE_IS_FREE(state,i)		\
+	(((state->lens[i]&(~0xf))==0) && state->ldata[i].job_in_lane==NULL)
+#define LANE_IS_INVALID(state,i)	\
+	(((state->lens[i]&(~0xf))!=0) && state->ldata[i].job_in_lane==NULL)
+void sha512_mb_mgr_init_ce(SHA512_MB_JOB_MGR * state)
+{
+	int i;
+	//~ state->unused_lanes = 0xf3210;
+	state->unused_lanes = 0xf;
+	state->num_lanes_inuse = 0;
+	for (i = SHA512_MB_CE_MAX_LANES - 1; i >= 0; i--) {
+		state->unused_lanes <<= 4;
+		state->unused_lanes |= i;
+		state->lens[i] = i;
+		state->ldata[i].job_in_lane = 0;
+	}
+
+	//lanes > SHA1_MB_CE_MAX_LANES is invalid lane
+	for (i = SHA512_MB_CE_MAX_LANES; i < SHA512_MAX_LANES; i++) {
+		state->lens[i] = 0xf;
+		state->ldata[i].job_in_lane = 0;
+	}
+}
+
+static int sha512_mb_mgr_do_jobs(SHA512_MB_JOB_MGR * state)
+{
+	int lane_idx, len, i, lanes;
+
+	int lane_idx_array[SHA512_MAX_LANES];
+
+	if (state->num_lanes_inuse == 0) {
+		return -1;
+	}
+#if	SHA512_MB_CE_MAX_LANES == 2
+	if (state->num_lanes_inuse == 2) {
+		len = min(state->lens[0], state->lens[1]);
+		lane_idx = len & 0xf;
+		len &= ~0xf;
+
+		sha512_mb_ce_x2(state->ldata[0].job_in_lane,
+				state->ldata[1].job_in_lane, len >> 4);
+
+	} else
+#endif
+	{
+		lanes = 0, len = 0;
+		for (i = 0; i < SHA512_MAX_LANES && lanes < state->num_lanes_inuse; i++) {
+			if (LANE_IS_NOT_FINISHED(state, i)) {
+				if (lanes)
+					len = min(len, state->lens[i]);
+				else
+					len = state->lens[i];
+				lane_idx_array[lanes] = i;
+				lanes++;
+			}
+		}
+		if (lanes == 0)
+			return -1;
+		lane_idx = len & 0xf;
+		len = len & (~0xf);
+
+#if SHA512_MB_CE_MAX_LANES >=2
+		if (lanes == 2) {
+			sha512_mb_ce_x2(state->ldata[lane_idx_array[0]].job_in_lane,
+					state->ldata[lane_idx_array[1]].job_in_lane, len >> 4);
+		} else
+#endif
+		{
+			sha512_mb_ce_x1(state->ldata[lane_idx_array[0]].job_in_lane, len >> 4);
+		}
+	}
+	//only return the min length job
+	for (i = 0; i < SHA512_MAX_LANES; i++) {
+		if (LANE_IS_NOT_FINISHED(state, i)) {
+			state->lens[i] -= len;
+			state->ldata[i].job_in_lane->len -= len;
+			state->ldata[i].job_in_lane->buffer += len << 3;
+		}
+	}
+
+	return lane_idx;
+
+}
+
+static SHA512_JOB *sha512_mb_mgr_free_lane(SHA512_MB_JOB_MGR * state)
+{
+	int i;
+	SHA512_JOB *ret = NULL;
+
+	for (i = 0; i < SHA512_MB_CE_MAX_LANES; i++) {
+		if (LANE_IS_FINISHED(state, i)) {
+
+			state->unused_lanes <<= 4;
+			state->unused_lanes |= i;
+			state->num_lanes_inuse--;
+			ret = state->ldata[i].job_in_lane;
+			ret->status = STS_COMPLETED;
+			state->ldata[i].job_in_lane = NULL;
+			break;
+		}
+	}
+	return ret;
+}
+
+static void sha512_mb_mgr_insert_job(SHA512_MB_JOB_MGR * state, SHA512_JOB * job)
+{
+	int lane_idx;
+	//add job into lanes
+	lane_idx = state->unused_lanes & 0xf;
+	//fatal error
+	assert(lane_idx < SHA512_MB_CE_MAX_LANES);
+	state->lens[lane_idx] = (job->len << 4) | lane_idx;
+	state->ldata[lane_idx].job_in_lane = job;
+	state->unused_lanes >>= 4;
+	state->num_lanes_inuse++;
+}
+
+SHA512_JOB *sha512_mb_mgr_submit_ce(SHA512_MB_JOB_MGR * state, SHA512_JOB * job)
+{
+#ifndef NDEBUG
+	int lane_idx;
+#endif
+	SHA512_JOB *ret;
+
+	//add job into lanes
+	sha512_mb_mgr_insert_job(state, job);
+
+	ret = sha512_mb_mgr_free_lane(state);
+	if (ret != NULL) {
+		return ret;
+	}
+	//submit will wait all lane has data
+	if (state->num_lanes_inuse < SHA512_MB_CE_MAX_LANES)
+		return NULL;
+#ifndef NDEBUG
+	lane_idx = sha512_mb_mgr_do_jobs(state);
+	assert(lane_idx != -1);
+#else
+	sha512_mb_mgr_do_jobs(state);
+#endif
+
+	//~ i = lane_idx;
+	ret = sha512_mb_mgr_free_lane(state);
+	return ret;
+}
+
+SHA512_JOB *sha512_mb_mgr_flush_ce(SHA512_MB_JOB_MGR * state)
+{
+	SHA512_JOB *ret;
+	ret = sha512_mb_mgr_free_lane(state);
+	if (ret) {
+		return ret;
+	}
+
+	sha512_mb_mgr_do_jobs(state);
+	return sha512_mb_mgr_free_lane(state);
+
+}

--- a/sha512_mb/aarch64/sha512_mb_multibinary.S
+++ b/sha512_mb/aarch64/sha512_mb_multibinary.S
@@ -1,0 +1,36 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+
+#include "multibinary_arm.h"
+
+
+mbin_dispatch sha512_ctx_mgr_submit
+mbin_dispatch sha512_ctx_mgr_init
+mbin_dispatch sha512_ctx_mgr_flush

--- a/sha512_mb/aarch64/sha512_mb_x1_ce.S
+++ b/sha512_mb/aarch64/sha512_mb_x1_ce.S
@@ -1,0 +1,269 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+	.arch armv8.2-a+crypto+sha3
+	.text
+	.align	2
+	.p2align 3,,7
+
+/*
+Macros
+*/
+
+.macro	declare_var_vector_reg name:req,reg:req
+	\name\()_q	.req	q\reg
+	\name\()_v	.req	v\reg
+	\name\()_s	.req	s\reg
+.endm
+/**
+maros for round 0-63
+*/
+.macro sha512_rounds_low ab,cd,ef,gh,tmp,msg0,msg1,msg4,msg5,msg7
+	ldr		key_q , [key_adr]
+	add		l0_tmp0_v.2d,l0_\msg0\()_v.2d,key_v.2d
+	add		key_adr,key_adr,16
+	ext		l0_tmp1_v.16b,l0_\ef\()_v.16b,l0_\gh\()_v.16b,#8
+	ext		l0_tmp0_v.16b,l0_tmp0_v.16b,l0_tmp0_v.16b,#8
+	ext		l0_tmp2_v.16b,l0_\cd\()_v.16b,l0_\ef\()_v.16b,#8
+	add		l0_\gh\()_v.2d,l0_\gh\()_v.2d,l0_tmp0_v.2d
+	ext		l0_tmp0_v.16b,l0_\msg4\()_v.16b,l0_\msg5\()_v.16b,#8
+	sha512su0	l0_\msg0\()_v.2d,l0_\msg1\()_v.2d
+	sha512h		l0_\gh\()_q,l0_tmp1_q,l0_tmp2_v.2d
+	sha512su1	l0_\msg0\()_v.2d,l0_\msg7\()_v.2d,l0_tmp0_v.2d
+	add		l0_\tmp\()_v.2d,l0_\cd\()_v.2d,l0_\gh\()_v.2d
+	sha512h2	l0_\gh\()_q,l0_\cd\()_q,l0_\ab\()_v.2d
+.endm
+/**
+maros for round 64-79
+*/
+.macro sha512_rounds_high	ab,cd,ef,gh,tmp,msg0
+	ldr		key_q , [key_adr]
+	add		l0_tmp0_v.2d,l0_\msg0\()_v.2d,key_v.2d
+	add		key_adr,key_adr,16
+	ext		l0_tmp1_v.16b,l0_\ef\()_v.16b,l0_\gh\()_v.16b,#8
+	ext		l0_tmp0_v.16b,l0_tmp0_v.16b,l0_tmp0_v.16b,#8
+	ext		l0_tmp2_v.16b,l0_\cd\()_v.16b,l0_\ef\()_v.16b,#8
+	add		l0_\gh\()_v.2d,l0_\gh\()_v.2d,l0_tmp0_v.2d
+	sha512h		l0_\gh\()_q,l0_tmp1_q,l0_tmp2_v.2d
+	add		l0_\tmp\()_v.2d,l0_\cd\()_v.2d,l0_\gh\()_v.2d
+	sha512h2	l0_\gh\()_q,l0_\cd\()_q,l0_\ab\()_v.2d
+.endm
+
+
+/*
+Variable list
+*/
+
+	declare_var_vector_reg	key,31
+
+
+/*
+digest variables
+*/
+	declare_var_vector_reg	l0_ab,0
+	declare_var_vector_reg	l0_cd,1
+	declare_var_vector_reg	l0_ef,2
+	declare_var_vector_reg	l0_gh,3
+
+	declare_var_vector_reg	l0_tmp,4
+	declare_var_vector_reg	l0_ab_saved,24
+	declare_var_vector_reg	l0_cd_saved,25
+	declare_var_vector_reg	l0_ef_saved,26
+	declare_var_vector_reg	l0_gh_saved,27
+/*
+Temporay variables
+*/
+	declare_var_vector_reg	l0_tmp0,5
+	declare_var_vector_reg	l0_tmp1,6
+	declare_var_vector_reg	l0_tmp2,7
+
+/*
+Message variables
+*/
+	declare_var_vector_reg	l0_msg0,16
+	declare_var_vector_reg	l0_msg1,17
+	declare_var_vector_reg	l0_msg2,18
+	declare_var_vector_reg	l0_msg3,19
+	declare_var_vector_reg	l0_msg4,20
+	declare_var_vector_reg	l0_msg5,21
+	declare_var_vector_reg	l0_msg6,22
+	declare_var_vector_reg	l0_msg7,23
+
+
+
+/*
+	void sha512_mb_ce_x1(SHA1_JOB * l0_job, int len);
+*/
+/*
+Arguements list
+*/
+	l0_job 	.req	x0
+	len	.req	w1
+	l0_data	.req	x2
+	key_adr	.req	x3
+	.global	sha512_mb_ce_x1
+	.type	sha512_mb_ce_x1, %function
+sha512_mb_ce_x1:
+	ldr	l0_data, [l0_job]
+	// load initial digest
+	add	x4,l0_job,64
+	ld1	{l0_ab_v.4s-l0_gh_v.4s},[x4]
+
+
+
+start_loop:
+	adr	key_adr, KEY
+	//load msgs
+	ld1	{l0_msg0_v.4s-l0_msg3_v.4s},[l0_data]
+	add	l0_data,l0_data,64
+	ld1	{l0_msg4_v.4s-l0_msg7_v.4s},[l0_data]
+	add	l0_data,l0_data,64
+	//adjust loop parameter
+
+	sub	len, len, #1
+	cmp	len, 0
+
+	//save state
+	mov	l0_ab_saved_v.16b,l0_ab_v.16b
+	mov	l0_cd_saved_v.16b,l0_cd_v.16b
+	mov	l0_ef_saved_v.16b,l0_ef_v.16b
+	mov	l0_gh_saved_v.16b,l0_gh_v.16b
+
+	//rev endian
+	rev64	l0_msg0_v.16b,l0_msg0_v.16b
+	rev64	l0_msg1_v.16b,l0_msg1_v.16b
+	rev64	l0_msg2_v.16b,l0_msg2_v.16b
+	rev64	l0_msg3_v.16b,l0_msg3_v.16b
+	rev64	l0_msg4_v.16b,l0_msg4_v.16b
+	rev64	l0_msg5_v.16b,l0_msg5_v.16b
+	rev64	l0_msg6_v.16b,l0_msg6_v.16b
+	rev64	l0_msg7_v.16b,l0_msg7_v.16b
+
+
+
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg0,msg1,msg4,msg5,msg7	/* rounds  0- 1 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg1,msg2,msg5,msg6,msg0	/* rounds  2- 3 */
+	sha512_rounds_low	 ef, gh, cd,tmp, ab,msg2,msg3,msg6,msg7,msg1	/* rounds  4- 5 */
+	sha512_rounds_low	tmp, ef, ab, cd, gh,msg3,msg4,msg7,msg0,msg2	/* rounds  6- 7 */
+	sha512_rounds_low	 cd,tmp, gh, ab, ef,msg4,msg5,msg0,msg1,msg3	/* rounds  8- 9 */
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg5,msg6,msg1,msg2,msg4	/* rounds 10-11 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg6,msg7,msg2,msg3,msg5	/* rounds 12-13 */
+	sha512_rounds_low	 ef, gh, cd,tmp, ab,msg7,msg0,msg3,msg4,msg6	/* rounds 14-15 */
+	sha512_rounds_low	tmp, ef, ab, cd, gh,msg0,msg1,msg4,msg5,msg7	/* rounds 16-17 */
+	sha512_rounds_low	 cd,tmp, gh, ab, ef,msg1,msg2,msg5,msg6,msg0	/* rounds 18-19 */
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg2,msg3,msg6,msg7,msg1	/* rounds 20-21 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg3,msg4,msg7,msg0,msg2	/* rounds 22-23 */
+	sha512_rounds_low	 ef, gh, cd,tmp, ab,msg4,msg5,msg0,msg1,msg3	/* rounds 24-25 */
+	sha512_rounds_low	tmp, ef, ab, cd, gh,msg5,msg6,msg1,msg2,msg4	/* rounds 26-27 */
+	sha512_rounds_low	 cd,tmp, gh, ab, ef,msg6,msg7,msg2,msg3,msg5	/* rounds 28-29 */
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg7,msg0,msg3,msg4,msg6	/* rounds 30-31 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg0,msg1,msg4,msg5,msg7	/* rounds 32-33 */
+	sha512_rounds_low	 ef, gh, cd,tmp, ab,msg1,msg2,msg5,msg6,msg0	/* rounds 34-35 */
+	sha512_rounds_low	tmp, ef, ab, cd, gh,msg2,msg3,msg6,msg7,msg1	/* rounds 36-37 */
+	sha512_rounds_low	 cd,tmp, gh, ab, ef,msg3,msg4,msg7,msg0,msg2	/* rounds 38-39 */
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg4,msg5,msg0,msg1,msg3	/* rounds 40-41 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg5,msg6,msg1,msg2,msg4	/* rounds 42-43 */
+	sha512_rounds_low	 ef, gh, cd,tmp, ab,msg6,msg7,msg2,msg3,msg5	/* rounds 44-45 */
+	sha512_rounds_low	tmp, ef, ab, cd, gh,msg7,msg0,msg3,msg4,msg6	/* rounds 46-47 */
+	sha512_rounds_low	 cd,tmp, gh, ab, ef,msg0,msg1,msg4,msg5,msg7	/* rounds 48-49 */
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg1,msg2,msg5,msg6,msg0	/* rounds 50-51 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg2,msg3,msg6,msg7,msg1	/* rounds 52-53 */
+	sha512_rounds_low	 ef, gh, cd,tmp, ab,msg3,msg4,msg7,msg0,msg2	/* rounds 54-55 */
+	sha512_rounds_low	tmp, ef, ab, cd, gh,msg4,msg5,msg0,msg1,msg3	/* rounds 56-57 */
+	sha512_rounds_low	 cd,tmp, gh, ab, ef,msg5,msg6,msg1,msg2,msg4	/* rounds 58-59 */
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg6,msg7,msg2,msg3,msg5	/* rounds 60-61 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg7,msg0,msg3,msg4,msg6	/* rounds 62-63 */
+	sha512_rounds_high	 ef, gh, cd,tmp, ab,msg0			/* rounds 64-65 */
+	sha512_rounds_high	tmp, ef, ab, cd, gh,msg1			/* rounds 66-67 */
+	sha512_rounds_high	 cd,tmp, gh, ab, ef,msg2			/* rounds 68-69 */
+	sha512_rounds_high	 ab, cd, ef, gh,tmp,msg3			/* rounds 70-71 */
+	sha512_rounds_high	 gh, ab,tmp, ef, cd,msg4			/* rounds 72-73 */
+	sha512_rounds_high	 ef, gh, cd,tmp, ab,msg5			/* rounds 74-75 */
+	sha512_rounds_high	tmp, ef, ab, cd, gh,msg6			/* rounds 76-77 */
+	sha512_rounds_high	 cd,tmp, gh, ab, ef,msg7			/* rounds 78-79 */
+
+
+
+	add	l0_ab_v.2d,l0_ab_v.2d,l0_ab_saved_v.2d
+	add	l0_cd_v.2d,l0_cd_v.2d,l0_cd_saved_v.2d
+	add	l0_ef_v.2d,l0_ef_v.2d,l0_ef_saved_v.2d
+	add	l0_gh_v.2d,l0_gh_v.2d,l0_gh_saved_v.2d
+
+
+	bgt	start_loop
+
+	add	x4,l0_job,64
+	st1	{l0_ab_v.4s-l0_gh_v.4s},[x4]
+
+
+	ret
+
+	.size	sha512_mb_ce_x1, .-sha512_mb_ce_x1
+	.section	.rol0_data.cst16,"aM",@progbits,16
+	.align	4
+KEY:
+	.quad		0x428a2f98d728ae22, 0x7137449123ef65cd
+	.quad		0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc
+	.quad		0x3956c25bf348b538, 0x59f111f1b605d019
+	.quad		0x923f82a4af194f9b, 0xab1c5ed5da6d8118
+	.quad		0xd807aa98a3030242, 0x12835b0145706fbe
+	.quad		0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2
+	.quad		0x72be5d74f27b896f, 0x80deb1fe3b1696b1
+	.quad		0x9bdc06a725c71235, 0xc19bf174cf692694
+	.quad		0xe49b69c19ef14ad2, 0xefbe4786384f25e3
+	.quad		0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65
+	.quad		0x2de92c6f592b0275, 0x4a7484aa6ea6e483
+	.quad		0x5cb0a9dcbd41fbd4, 0x76f988da831153b5
+	.quad		0x983e5152ee66dfab, 0xa831c66d2db43210
+	.quad		0xb00327c898fb213f, 0xbf597fc7beef0ee4
+	.quad		0xc6e00bf33da88fc2, 0xd5a79147930aa725
+	.quad		0x06ca6351e003826f, 0x142929670a0e6e70
+	.quad		0x27b70a8546d22ffc, 0x2e1b21385c26c926
+	.quad		0x4d2c6dfc5ac42aed, 0x53380d139d95b3df
+	.quad		0x650a73548baf63de, 0x766a0abb3c77b2a8
+	.quad		0x81c2c92e47edaee6, 0x92722c851482353b
+	.quad		0xa2bfe8a14cf10364, 0xa81a664bbc423001
+	.quad		0xc24b8b70d0f89791, 0xc76c51a30654be30
+	.quad		0xd192e819d6ef5218, 0xd69906245565a910
+	.quad		0xf40e35855771202a, 0x106aa07032bbd1b8
+	.quad		0x19a4c116b8d2d0c8, 0x1e376c085141ab53
+	.quad		0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8
+	.quad		0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb
+	.quad		0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3
+	.quad		0x748f82ee5defb2fc, 0x78a5636f43172f60
+	.quad		0x84c87814a1f0ab72, 0x8cc702081a6439ec
+	.quad		0x90befffa23631e28, 0xa4506cebde82bde9
+	.quad		0xbef9a3f7b2c67915, 0xc67178f2e372532b
+	.quad		0xca273eceea26619c, 0xd186b8c721c0c207
+	.quad		0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178
+	.quad		0x06f067aa72176fba, 0x0a637dc5a2c898a6
+	.quad		0x113f9804bef90dae, 0x1b710b35131c471b
+	.quad		0x28db77f523047d84, 0x32caab7b40c72493
+	.quad		0x3c9ebe0a15c9bebc, 0x431d67c49c100d4c
+	.quad		0x4cc5d4becb3e42b6, 0x597f299cfc657e2a
+	.quad		0x5fcb6fab3ad6faec, 0x6c44198c4a475817

--- a/sha512_mb/aarch64/sha512_mb_x2_ce.S
+++ b/sha512_mb/aarch64/sha512_mb_x2_ce.S
@@ -1,0 +1,390 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+	.arch armv8.2-a+crypto+sha3
+	.text
+	.align	2
+	.p2align 3,,7
+
+/*
+Macros
+*/
+
+.macro	declare_var_vector_reg name:req,reg:req
+	\name\()_q	.req	q\reg
+	\name\()_v	.req	v\reg
+	\name\()_s	.req	s\reg
+.endm
+/**
+maros for round 0-63
+*/
+.macro sha512_rounds_low ab,cd,ef,gh,tmp,msg0,msg1,msg4,msg5,msg7
+	ldr		key_q , [key_adr]
+	add		l0_tmp0_v.2d,l0_\msg0\()_v.2d,key_v.2d
+	add		l1_tmp0_v.2d,l1_\msg0\()_v.2d,key_v.2d
+	add		key_adr,key_adr,16
+
+
+	ext		l0_tmp1_v.16b,l0_\ef\()_v.16b,l0_\gh\()_v.16b,#8
+	ext		l1_tmp1_v.16b,l1_\ef\()_v.16b,l1_\gh\()_v.16b,#8
+
+
+	ext		l0_tmp0_v.16b,l0_tmp0_v.16b,l0_tmp0_v.16b,#8
+	ext		l1_tmp0_v.16b,l1_tmp0_v.16b,l1_tmp0_v.16b,#8
+
+
+	ext		l0_tmp2_v.16b,l0_\cd\()_v.16b,l0_\ef\()_v.16b,#8
+	ext		l1_tmp2_v.16b,l1_\cd\()_v.16b,l1_\ef\()_v.16b,#8
+
+
+	add		l0_\gh\()_v.2d,l0_\gh\()_v.2d,l0_tmp0_v.2d
+	add		l1_\gh\()_v.2d,l1_\gh\()_v.2d,l1_tmp0_v.2d
+
+
+	ext		l0_tmp0_v.16b,l0_\msg4\()_v.16b,l0_\msg5\()_v.16b,#8
+	ext		l1_tmp0_v.16b,l1_\msg4\()_v.16b,l1_\msg5\()_v.16b,#8
+
+	sha512su0	l0_\msg0\()_v.2d,l0_\msg1\()_v.2d
+	sha512su0	l1_\msg0\()_v.2d,l1_\msg1\()_v.2d
+
+	sha512h		l0_\gh\()_q,l0_tmp1_q,l0_tmp2_v.2d
+	sha512h		l1_\gh\()_q,l1_tmp1_q,l1_tmp2_v.2d
+
+	sha512su1	l0_\msg0\()_v.2d,l0_\msg7\()_v.2d,l0_tmp0_v.2d
+	sha512su1	l1_\msg0\()_v.2d,l1_\msg7\()_v.2d,l1_tmp0_v.2d
+
+	add		l0_\tmp\()_v.2d,l0_\cd\()_v.2d,l0_\gh\()_v.2d
+	add		l1_\tmp\()_v.2d,l1_\cd\()_v.2d,l1_\gh\()_v.2d
+
+	sha512h2	l0_\gh\()_q,l0_\cd\()_q,l0_\ab\()_v.2d
+	sha512h2	l1_\gh\()_q,l1_\cd\()_q,l1_\ab\()_v.2d
+.endm
+
+/**
+maros for round 64-79
+*/
+.macro sha512_rounds_high	ab,cd,ef,gh,tmp,msg0
+	ldr		key_q , [key_adr]
+	add		l0_tmp0_v.2d,l0_\msg0\()_v.2d,key_v.2d
+	add		l1_tmp0_v.2d,l1_\msg0\()_v.2d,key_v.2d
+	add		key_adr,key_adr,16
+
+
+	ext		l0_tmp1_v.16b,l0_\ef\()_v.16b,l0_\gh\()_v.16b,#8
+	ext		l1_tmp1_v.16b,l1_\ef\()_v.16b,l1_\gh\()_v.16b,#8
+
+
+	ext		l0_tmp0_v.16b,l0_tmp0_v.16b,l0_tmp0_v.16b,#8
+	ext		l1_tmp0_v.16b,l1_tmp0_v.16b,l1_tmp0_v.16b,#8
+
+
+	ext		l0_tmp2_v.16b,l0_\cd\()_v.16b,l0_\ef\()_v.16b,#8
+	ext		l1_tmp2_v.16b,l1_\cd\()_v.16b,l1_\ef\()_v.16b,#8
+
+
+	add		l0_\gh\()_v.2d,l0_\gh\()_v.2d,l0_tmp0_v.2d
+	add		l1_\gh\()_v.2d,l1_\gh\()_v.2d,l1_tmp0_v.2d
+
+
+
+	sha512h		l0_\gh\()_q,l0_tmp1_q,l0_tmp2_v.2d
+	sha512h		l1_\gh\()_q,l1_tmp1_q,l1_tmp2_v.2d
+
+
+	add		l0_\tmp\()_v.2d,l0_\cd\()_v.2d,l0_\gh\()_v.2d
+	add		l1_\tmp\()_v.2d,l1_\cd\()_v.2d,l1_\gh\()_v.2d
+
+	sha512h2	l0_\gh\()_q,l0_\cd\()_q,l0_\ab\()_v.2d
+	sha512h2	l1_\gh\()_q,l1_\cd\()_q,l1_\ab\()_v.2d
+.endm
+
+
+/*
+Variable list
+*/
+
+	declare_var_vector_reg	key,6
+
+
+/*
+digest variables
+*/
+	declare_var_vector_reg	l0_ab,0
+	declare_var_vector_reg	l0_cd,1
+	declare_var_vector_reg	l0_ef,2
+	declare_var_vector_reg	l0_gh,3
+	declare_var_vector_reg	l0_tmp,4
+
+	declare_var_vector_reg	l1_ab,8
+	declare_var_vector_reg	l1_cd,9
+	declare_var_vector_reg	l1_ef,10
+	declare_var_vector_reg	l1_gh,11
+	declare_var_vector_reg	l1_tmp,12
+
+
+	declare_var_vector_reg	l0_ab_saved,16
+	declare_var_vector_reg	l0_cd_saved,17
+	declare_var_vector_reg	l0_ef_saved,18
+	declare_var_vector_reg	l0_gh_saved,19
+	declare_var_vector_reg	l1_ab_saved,24
+	declare_var_vector_reg	l1_cd_saved,25
+	declare_var_vector_reg	l1_ef_saved,26
+	declare_var_vector_reg	l1_gh_saved,27
+/*
+Temporay variables
+*/
+	declare_var_vector_reg	l0_tmp0,5
+	declare_var_vector_reg	l0_tmp1,6
+	declare_var_vector_reg	l0_tmp2,7
+
+	declare_var_vector_reg	l1_tmp0,13
+	declare_var_vector_reg	l1_tmp1,14
+	declare_var_vector_reg	l1_tmp2,15
+
+
+
+/*
+Message variables
+*/
+	declare_var_vector_reg	l0_msg0,16
+	declare_var_vector_reg	l0_msg1,17
+	declare_var_vector_reg	l0_msg2,18
+	declare_var_vector_reg	l0_msg3,19
+	declare_var_vector_reg	l0_msg4,20
+	declare_var_vector_reg	l0_msg5,21
+	declare_var_vector_reg	l0_msg6,22
+	declare_var_vector_reg	l0_msg7,23
+
+	declare_var_vector_reg	l1_msg0,24
+	declare_var_vector_reg	l1_msg1,25
+	declare_var_vector_reg	l1_msg2,26
+	declare_var_vector_reg	l1_msg3,27
+	declare_var_vector_reg	l1_msg4,28
+	declare_var_vector_reg	l1_msg5,29
+	declare_var_vector_reg	l1_msg6,30
+	declare_var_vector_reg	l1_msg7,31
+
+
+
+/*
+	void sha512_mb_ce_x2(SHA512_JOB *, SHA512_JOB *, int);
+*/
+/*
+Arguements list
+*/
+	l0_job 	.req	x0
+	l1_job 	.req	x1
+	len	.req	w2
+	l0_data	.req	x3
+	l1_data	.req	x4
+	key_adr	.req	x5
+	l0_digest_adr .req x6
+	l1_digest_adr .req x7
+	.global	sha512_mb_ce_x2
+	.type	sha512_mb_ce_x2, %function
+sha512_mb_ce_x2:
+	//push d8~d15
+	stp 	d8,d9,[sp,-192]!
+	stp 	d10,d11,[sp,16]
+	stp 	d12,d13,[sp,32]
+	stp 	d14,d15,[sp,48]
+
+
+	ldr	l0_data, [l0_job]
+	ldr	l1_data, [l1_job]
+	// load initial digest
+	add	l0_digest_adr,l0_job,64
+	add	l1_digest_adr,l1_job,64
+	ld1	{l0_ab_v.4s-l0_gh_v.4s},[l0_digest_adr]
+	ld1	{l1_ab_v.4s-l1_gh_v.4s},[l1_digest_adr]
+
+
+
+start_loop:
+
+	adr	key_adr, KEY
+	//load msgs
+	ld1	{l0_msg0_v.4s-l0_msg3_v.4s},[l0_data]
+	add	l0_data,l0_data,64
+	ld1	{l0_msg4_v.4s-l0_msg7_v.4s},[l0_data]
+	add	l0_data,l0_data,64
+
+	ld1	{l1_msg0_v.4s-l1_msg3_v.4s},[l1_data]
+	add	l1_data,l1_data,64
+	ld1	{l1_msg4_v.4s-l1_msg7_v.4s},[l1_data]
+	add	l1_data,l1_data,64
+
+	//adjust loop parameter
+	sub	len, len, #1
+	cmp	len, 0
+
+
+
+	//rev endian
+	rev64	l0_msg0_v.16b,l0_msg0_v.16b
+	rev64	l0_msg1_v.16b,l0_msg1_v.16b
+	rev64	l0_msg2_v.16b,l0_msg2_v.16b
+	rev64	l0_msg3_v.16b,l0_msg3_v.16b
+	rev64	l0_msg4_v.16b,l0_msg4_v.16b
+	rev64	l0_msg5_v.16b,l0_msg5_v.16b
+	rev64	l0_msg6_v.16b,l0_msg6_v.16b
+	rev64	l0_msg7_v.16b,l0_msg7_v.16b
+
+	rev64	l1_msg0_v.16b,l1_msg0_v.16b
+	rev64	l1_msg1_v.16b,l1_msg1_v.16b
+	rev64	l1_msg2_v.16b,l1_msg2_v.16b
+	rev64	l1_msg3_v.16b,l1_msg3_v.16b
+	rev64	l1_msg4_v.16b,l1_msg4_v.16b
+	rev64	l1_msg5_v.16b,l1_msg5_v.16b
+	rev64	l1_msg6_v.16b,l1_msg6_v.16b
+	rev64	l1_msg7_v.16b,l1_msg7_v.16b
+
+
+
+
+
+
+
+
+
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg0,msg1,msg4,msg5,msg7	/* rounds  0- 1 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg1,msg2,msg5,msg6,msg0	/* rounds  2- 3 */
+	sha512_rounds_low	 ef, gh, cd,tmp, ab,msg2,msg3,msg6,msg7,msg1	/* rounds  4- 5 */
+	sha512_rounds_low	tmp, ef, ab, cd, gh,msg3,msg4,msg7,msg0,msg2	/* rounds  6- 7 */
+	sha512_rounds_low	 cd,tmp, gh, ab, ef,msg4,msg5,msg0,msg1,msg3	/* rounds  8- 9 */
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg5,msg6,msg1,msg2,msg4	/* rounds 10-11 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg6,msg7,msg2,msg3,msg5	/* rounds 12-13 */
+	sha512_rounds_low	 ef, gh, cd,tmp, ab,msg7,msg0,msg3,msg4,msg6	/* rounds 14-15 */
+	sha512_rounds_low	tmp, ef, ab, cd, gh,msg0,msg1,msg4,msg5,msg7	/* rounds 16-17 */
+	sha512_rounds_low	 cd,tmp, gh, ab, ef,msg1,msg2,msg5,msg6,msg0	/* rounds 18-19 */
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg2,msg3,msg6,msg7,msg1	/* rounds 20-21 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg3,msg4,msg7,msg0,msg2	/* rounds 22-23 */
+	sha512_rounds_low	 ef, gh, cd,tmp, ab,msg4,msg5,msg0,msg1,msg3	/* rounds 24-25 */
+	sha512_rounds_low	tmp, ef, ab, cd, gh,msg5,msg6,msg1,msg2,msg4	/* rounds 26-27 */
+	sha512_rounds_low	 cd,tmp, gh, ab, ef,msg6,msg7,msg2,msg3,msg5	/* rounds 28-29 */
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg7,msg0,msg3,msg4,msg6	/* rounds 30-31 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg0,msg1,msg4,msg5,msg7	/* rounds 32-33 */
+	sha512_rounds_low	 ef, gh, cd,tmp, ab,msg1,msg2,msg5,msg6,msg0	/* rounds 34-35 */
+	sha512_rounds_low	tmp, ef, ab, cd, gh,msg2,msg3,msg6,msg7,msg1	/* rounds 36-37 */
+	sha512_rounds_low	 cd,tmp, gh, ab, ef,msg3,msg4,msg7,msg0,msg2	/* rounds 38-39 */
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg4,msg5,msg0,msg1,msg3	/* rounds 40-41 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg5,msg6,msg1,msg2,msg4	/* rounds 42-43 */
+	sha512_rounds_low	 ef, gh, cd,tmp, ab,msg6,msg7,msg2,msg3,msg5	/* rounds 44-45 */
+	sha512_rounds_low	tmp, ef, ab, cd, gh,msg7,msg0,msg3,msg4,msg6	/* rounds 46-47 */
+	sha512_rounds_low	 cd,tmp, gh, ab, ef,msg0,msg1,msg4,msg5,msg7	/* rounds 48-49 */
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg1,msg2,msg5,msg6,msg0	/* rounds 50-51 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg2,msg3,msg6,msg7,msg1	/* rounds 52-53 */
+	sha512_rounds_low	 ef, gh, cd,tmp, ab,msg3,msg4,msg7,msg0,msg2	/* rounds 54-55 */
+	sha512_rounds_low	tmp, ef, ab, cd, gh,msg4,msg5,msg0,msg1,msg3	/* rounds 56-57 */
+	sha512_rounds_low	 cd,tmp, gh, ab, ef,msg5,msg6,msg1,msg2,msg4	/* rounds 58-59 */
+	sha512_rounds_low	 ab, cd, ef, gh,tmp,msg6,msg7,msg2,msg3,msg5	/* rounds 60-61 */
+	sha512_rounds_low	 gh, ab,tmp, ef, cd,msg7,msg0,msg3,msg4,msg6	/* rounds 62-63 */
+	sha512_rounds_high	 ef, gh, cd,tmp, ab,msg0			/* rounds 64-65 */
+	sha512_rounds_high	tmp, ef, ab, cd, gh,msg1			/* rounds 66-67 */
+	sha512_rounds_high	 cd,tmp, gh, ab, ef,msg2			/* rounds 68-69 */
+	sha512_rounds_high	 ab, cd, ef, gh,tmp,msg3			/* rounds 70-71 */
+	ld1	{l0_ab_saved_v.4s-l0_gh_saved_v.4s},[l0_digest_adr]
+	ld1	{l1_ab_saved_v.4s-l1_gh_saved_v.4s},[l1_digest_adr]
+	sha512_rounds_high	 gh, ab,tmp, ef, cd,msg4			/* rounds 72-73 */
+	sha512_rounds_high	 ef, gh, cd,tmp, ab,msg5			/* rounds 74-75 */
+	sha512_rounds_high	tmp, ef, ab, cd, gh,msg6			/* rounds 76-77 */
+	sha512_rounds_high	 cd,tmp, gh, ab, ef,msg7			/* rounds 78-79 */
+
+
+
+	add	l0_ab_v.2d,l0_ab_v.2d,l0_ab_saved_v.2d
+	add	l0_cd_v.2d,l0_cd_v.2d,l0_cd_saved_v.2d
+	add	l0_ef_v.2d,l0_ef_v.2d,l0_ef_saved_v.2d
+	add	l0_gh_v.2d,l0_gh_v.2d,l0_gh_saved_v.2d
+	st1	{l0_ab_v.2d-l0_gh_v.2d},[l0_digest_adr]
+
+	add	l1_ab_v.2d,l1_ab_v.2d,l1_ab_saved_v.2d
+	add	l1_cd_v.2d,l1_cd_v.2d,l1_cd_saved_v.2d
+	add	l1_ef_v.2d,l1_ef_v.2d,l1_ef_saved_v.2d
+	add	l1_gh_v.2d,l1_gh_v.2d,l1_gh_saved_v.2d
+	st1	{l1_ab_v.2d-l1_gh_v.2d},[l1_digest_adr]
+
+
+
+
+	bgt	start_loop
+
+	add	x4,l0_job,64
+
+
+	ldp 	d10,d11,[sp,16]
+	ldp 	d12,d13,[sp,32]
+	ldp 	d14,d15,[sp,48]
+	ldp     d8, d9, [sp], 192
+
+	ret
+
+	.size	sha512_mb_ce_x2, .-sha512_mb_ce_x2
+	.section	.rol0_data.cst16,"aM",@progbits,16
+	.align	4
+KEY:
+	.quad		0x428a2f98d728ae22, 0x7137449123ef65cd
+	.quad		0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc
+	.quad		0x3956c25bf348b538, 0x59f111f1b605d019
+	.quad		0x923f82a4af194f9b, 0xab1c5ed5da6d8118
+	.quad		0xd807aa98a3030242, 0x12835b0145706fbe
+	.quad		0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2
+	.quad		0x72be5d74f27b896f, 0x80deb1fe3b1696b1
+	.quad		0x9bdc06a725c71235, 0xc19bf174cf692694
+	.quad		0xe49b69c19ef14ad2, 0xefbe4786384f25e3
+	.quad		0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65
+	.quad		0x2de92c6f592b0275, 0x4a7484aa6ea6e483
+	.quad		0x5cb0a9dcbd41fbd4, 0x76f988da831153b5
+	.quad		0x983e5152ee66dfab, 0xa831c66d2db43210
+	.quad		0xb00327c898fb213f, 0xbf597fc7beef0ee4
+	.quad		0xc6e00bf33da88fc2, 0xd5a79147930aa725
+	.quad		0x06ca6351e003826f, 0x142929670a0e6e70
+	.quad		0x27b70a8546d22ffc, 0x2e1b21385c26c926
+	.quad		0x4d2c6dfc5ac42aed, 0x53380d139d95b3df
+	.quad		0x650a73548baf63de, 0x766a0abb3c77b2a8
+	.quad		0x81c2c92e47edaee6, 0x92722c851482353b
+	.quad		0xa2bfe8a14cf10364, 0xa81a664bbc423001
+	.quad		0xc24b8b70d0f89791, 0xc76c51a30654be30
+	.quad		0xd192e819d6ef5218, 0xd69906245565a910
+	.quad		0xf40e35855771202a, 0x106aa07032bbd1b8
+	.quad		0x19a4c116b8d2d0c8, 0x1e376c085141ab53
+	.quad		0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8
+	.quad		0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb
+	.quad		0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3
+	.quad		0x748f82ee5defb2fc, 0x78a5636f43172f60
+	.quad		0x84c87814a1f0ab72, 0x8cc702081a6439ec
+	.quad		0x90befffa23631e28, 0xa4506cebde82bde9
+	.quad		0xbef9a3f7b2c67915, 0xc67178f2e372532b
+	.quad		0xca273eceea26619c, 0xd186b8c721c0c207
+	.quad		0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178
+	.quad		0x06f067aa72176fba, 0x0a637dc5a2c898a6
+	.quad		0x113f9804bef90dae, 0x1b710b35131c471b
+	.quad		0x28db77f523047d84, 0x32caab7b40c72493
+	.quad		0x3c9ebe0a15c9bebc, 0x431d67c49c100d4c
+	.quad		0x4cc5d4becb3e42b6, 0x597f299cfc657e2a
+	.quad		0x5fcb6fab3ad6faec, 0x6c44198c4a475817

--- a/sha512_mb/sha512_ctx_base_aliases.c
+++ b/sha512_mb/sha512_ctx_base_aliases.c
@@ -1,0 +1,54 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stdint.h>
+#include <string.h>
+#include "sha512_mb.h"
+#include "memcpy_inline.h"
+
+extern void sha512_ctx_mgr_init_base(SHA512_HASH_CTX_MGR * mgr);
+extern SHA512_HASH_CTX *sha512_ctx_mgr_submit_base(SHA512_HASH_CTX_MGR * mgr,
+						   SHA512_HASH_CTX * ctx, const void *buffer,
+						   uint32_t len, HASH_CTX_FLAG flags);
+extern SHA512_HASH_CTX *sha512_ctx_mgr_flush_base(SHA512_HASH_CTX_MGR * mgr);
+
+void sha512_ctx_mgr_init(SHA512_HASH_CTX_MGR * mgr)
+{
+	return sha512_ctx_mgr_init_base(mgr);
+}
+
+SHA512_HASH_CTX *sha512_ctx_mgr_submit(SHA512_HASH_CTX_MGR * mgr, SHA512_HASH_CTX * ctx,
+				       const void *buffer, uint32_t len, HASH_CTX_FLAG flags)
+{
+	return sha512_ctx_mgr_submit_base(mgr, ctx, buffer, len, flags);
+}
+
+SHA512_HASH_CTX *sha512_ctx_mgr_flush(SHA512_HASH_CTX_MGR * mgr)
+{
+	return sha512_ctx_mgr_flush_base(mgr);
+}


### PR DESCRIPTION
Arm64 crypto extention support sha256/512 instruction .
This PR implement SHA256/512 with the instructions .