### PR TITLE
build: add base aliases files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,15 +34,20 @@ perf_tests32=
 # Include units
 include sha1_mb/Makefile.am
 include mh_sha1/Makefile.am
-if !CPU_AARCH64
 include md5_mb/Makefile.am
 include sha256_mb/Makefile.am
 include sha512_mb/Makefile.am
 include mh_sha1_murmur3_x64_128/Makefile.am
 include mh_sha256/Makefile.am
-include aes/Makefile.am
 include rolling_hash/Makefile.am
 include sm3_mb/Makefile.am
+
+if CPU_X86_64
+include aes/Makefile.am
+endif
+
+if CPU_X86_32
+include aes/Makefile.am
 endif
 
 # LIB version info not necessarily the same as package version

--- a/Makefile.unx
+++ b/Makefile.unx
@@ -29,9 +29,18 @@
 
 units_x86_64     = sha1_mb sha256_mb sha512_mb md5_mb mh_sha1 mh_sha1_murmur3_x64_128 mh_sha256 aes rolling_hash sm3_mb
 units_x86_32     = $(units_x86_64)
-units_aarch64    = sha1_mb mh_sha1
+
+#aes does not include base alias implement
+units_aarch64    = sha1_mb sha256_mb sha512_mb md5_mb mh_sha1 mh_sha1_murmur3_x64_128 mh_sha256 rolling_hash sm3_mb
+
 host_cpu ?= $(shell uname -m | sed -e 's/amd/x86_/')
-units ?= $(units_$(host_cpu))
+
+ifneq ($(filter aarch64 x86_%,$(host_cpu)),)
+  units ?= $(units_$(host_cpu))
+else
+  # host_cpu is not supported , set the list support base aliases
+  units ?= sha1_mb sha256_mb sha512_mb md5_mb mh_sha1 mh_sha1_murmur3_x64_128 mh_sha256 rolling_hash sm3_mb
+endif
 
 default: lib
 

--- a/make.inc
+++ b/make.inc
@@ -42,8 +42,9 @@
 version ?= 2.22.0
 host_cpu ?= $(shell uname -m | sed -e 's/amd/x86_/')
 arch ?= $(shell uname | grep -v -e Linux -e BSD )
+
 ifeq ($(host_cpu)_$(arch),aarch64_)
-arch = aarch64
+  arch = aarch64
 endif
 
 
@@ -77,10 +78,6 @@ ASFLAGS_mingw = -f win64
 ARFLAGS_mingw = cr $@
 LDFLAGS_mingw = -Wl,--force-exe-suffix
 
-# arch=aarch64 build options
-ASFLAGS_aarch64 = -D__ASSEMBLY__ -c
-ARFLAGS_aarch64 = cr $@
-
 LDFLAGS_so = -Wl,-soname,$(soname)
 
 ifeq ($(arch),mingw)
@@ -95,8 +92,11 @@ ifeq ($(shell uname),Darwin)
    STRIP_gcc  =
 endif
 
+# arch=aarch64 build options
+ASFLAGS_aarch64 = -c
+ARFLAGS_aarch64 = cr $@
 ifeq ($(arch),aarch64)
-  AS=gcc
+  AS=$(CC) -D__ASSEMBLY__
   SIM=
 endif
 
@@ -106,6 +106,9 @@ ASFLAGS  = $(ASFLAGS_$(arch)) $(ASFLAGS_$(CC)) $(DEBUG_$(AS)) $(DEFINES) $(INCLU
 ARFLAGS  = $(ARFLAGS_$(arch))
 DEFINES += $(addprefix -D , $D)
 
+ifeq ($(filter aarch64 x86_%,$(host_cpu)),)
+  host_cpu=base_aliases
+endif
 lsrc += $(lsrc_$(host_cpu))
 O = bin
 lobj  += $(patsubst %.c,%.o,$(patsubst %.S,%.o,$(patsubst %.asm,%.o,$(lsrc) $(lsrc_intrinsic))))

--- a/md5_mb/Makefile.am
+++ b/md5_mb/Makefile.am
@@ -54,8 +54,10 @@ lsrc_x86_64 += 	md5_mb/md5_mb_mgr_submit_avx512.asm \
 
 lsrc_x86_32 += $(lsrc_x86_64)
 
-lsrc_aarch64 += md5_mb/md5_ctx_base.c
-
+lsrc_aarch64 += md5_mb/md5_ctx_base.c \
+		md5_mb/md5_ctx_base_aliases.c
+lsrc_base_aliases += md5_mb/md5_ctx_base.c \
+		md5_mb/md5_ctx_base_aliases.c
 src_include  += -I $(srcdir)/md5_mb
 extern_hdrs  += include/md5_mb.h \
 		include/multi_buffer.h

--- a/md5_mb/md5_ctx_base_aliases.c
+++ b/md5_mb/md5_ctx_base_aliases.c
@@ -1,0 +1,50 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <string.h>
+#include "md5_mb.h"
+extern void md5_ctx_mgr_init_base(MD5_HASH_CTX_MGR * mgr);
+extern MD5_HASH_CTX *md5_ctx_mgr_flush_base(MD5_HASH_CTX_MGR * mgr);
+extern MD5_HASH_CTX *md5_ctx_mgr_submit_base(MD5_HASH_CTX_MGR * mgr, MD5_HASH_CTX * ctx,
+					     const void *buffer, uint32_t len,
+					     HASH_CTX_FLAG flags);
+void md5_ctx_mgr_init(MD5_HASH_CTX_MGR * mgr)
+{
+	md5_ctx_mgr_init_base(mgr);
+}
+
+MD5_HASH_CTX *md5_ctx_mgr_flush(MD5_HASH_CTX_MGR * mgr)
+{
+	return md5_ctx_mgr_flush_base(mgr);
+}
+
+MD5_HASH_CTX *md5_ctx_mgr_submit(MD5_HASH_CTX_MGR * mgr, MD5_HASH_CTX * ctx,
+				 const void *buffer, uint32_t len, HASH_CTX_FLAG flags)
+{
+	return md5_ctx_mgr_submit_base(mgr, ctx, buffer, len, flags);
+}

--- a/mh_sha1_murmur3_x64_128/Makefile.am
+++ b/mh_sha1_murmur3_x64_128/Makefile.am
@@ -45,6 +45,18 @@ lsrc_x86_64  += $(lsrc_murmur) \
 
 lsrc_x86_32  += $(lsrc_x86_64)
 
+lsrc_aarch64 += $(lsrc_murmur)	\
+		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128.c \
+		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128_finalize_base.c \
+		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128_update_base.c \
+		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128_base_aliases.c
+
+lsrc_base_aliases += $(lsrc_murmur)	\
+		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128.c \
+		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128_finalize_base.c \
+		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128_update_base.c \
+		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128_base_aliases.c
+
 other_src += 	include/reg_sizes.asm \
 		include/multibinary.asm \
 		include/test.h \

--- a/mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128.c
+++ b/mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128.c
@@ -74,6 +74,8 @@ void mh_sha1_murmur3_x64_128_block_base(const uint8_t * input_data,
 	return;
 }
 
+#if defined(__i386__) || defined(__x86_64__) || defined( _M_X64) \
+	|| defined(_M_IX86)
 /***************mh_sha1_murmur3_x64_128_update***********/
 // mh_sha1_murmur3_x64_128_update_sse.c
 #define UPDATE_FUNCTION mh_sha1_murmur3_x64_128_update_sse
@@ -149,3 +151,4 @@ struct slver mh_sha1_murmur3_x64_128_finalize_avx_slver = { 0x0257, 0x00, 0x02 }
 
 struct slver mh_sha1_murmur3_x64_128_finalize_avx2_slver_04000259;
 struct slver mh_sha1_murmur3_x64_128_finalize_avx2_slver = { 0x0259, 0x00, 0x04 };
+#endif

--- a/mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128_base_aliases.c
+++ b/mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128_base_aliases.c
@@ -1,0 +1,43 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include "mh_sha1_murmur3_x64_128_internal.h"
+#include <string.h>
+int mh_sha1_murmur3_x64_128_update(struct mh_sha1_murmur3_x64_128_ctx *ctx, const void *buffer,
+				   uint32_t len)
+{
+	return mh_sha1_murmur3_x64_128_update_base(ctx, buffer, len);
+
+}
+
+int mh_sha1_murmur3_x64_128_finalize(struct mh_sha1_murmur3_x64_128_ctx *ctx,
+				     void *mh_sha1_digest, void *murmur3_x64_128_digest)
+{
+	return mh_sha1_murmur3_x64_128_finalize_base(ctx, mh_sha1_digest,
+						     murmur3_x64_128_digest);
+}

--- a/mh_sha256/Makefile.am
+++ b/mh_sha256/Makefile.am
@@ -52,6 +52,20 @@ other_src   += 	mh_sha256/mh_sha256_ref.c \
 		include/test.h \
 		mh_sha256/mh_sha256_internal.h
 
+lsrc_aarch64 += $(lsrc_sha256)	\
+		mh_sha256/mh_sha256_base_aliases.c \
+		mh_sha256/mh_sha256.c \
+		mh_sha256/mh_sha256_finalize_base.c \
+		mh_sha256/mh_sha256_update_base.c \
+		mh_sha256/mh_sha256_block_base.c
+
+lsrc_base_aliases += $(lsrc_sha256)	\
+		mh_sha256/mh_sha256_base_aliases.c \
+		mh_sha256/mh_sha256.c \
+		mh_sha256/mh_sha256_finalize_base.c \
+		mh_sha256/mh_sha256_update_base.c \
+		mh_sha256/mh_sha256_block_base.c
+
 src_include += -I $(srcdir)/mh_sha256
 
 extern_hdrs +=	include/mh_sha256.h

--- a/mh_sha256/mh_sha256.c
+++ b/mh_sha256/mh_sha256.c
@@ -55,6 +55,8 @@ int mh_sha256_init(struct mh_sha256_ctx *ctx)
 	return MH_SHA256_CTX_ERROR_NONE;
 }
 
+#if defined(__i386__) || defined(__x86_64__) || defined( _M_X64) \
+	|| defined(_M_IX86)
 /***************mh_sha256_update***********/
 // mh_sha256_update_sse.c
 #define MH_SHA256_UPDATE_FUNCTION	mh_sha256_update_sse
@@ -138,3 +140,4 @@ struct slver mh_sha256_finalize_avx_slver = { 0x02b7, 0x00, 0x02 };
 
 struct slver mh_sha256_finalize_avx2_slver_040002b9;
 struct slver mh_sha256_finalize_avx2_slver = { 0x02b9, 0x00, 0x04 };
+#endif

--- a/mh_sha256/mh_sha256_base_aliases.c
+++ b/mh_sha256/mh_sha256_base_aliases.c
@@ -1,0 +1,40 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include "mh_sha256_internal.h"
+#include <string.h>
+int mh_sha256_update(struct mh_sha256_ctx *ctx, const void *buffer, uint32_t len)
+{
+	return mh_sha256_update_base(ctx, buffer, len);
+
+}
+
+int mh_sha256_finalize(struct mh_sha256_ctx *ctx, void *mh_sha256_digest)
+{
+	return mh_sha256_finalize_base(ctx, mh_sha256_digest);
+}

--- a/rolling_hash/Makefile.am
+++ b/rolling_hash/Makefile.am
@@ -35,6 +35,15 @@ lsrc_x86_64         += rolling_hash/rolling_hash2_multibinary.asm
 
 lsrc_x86_32         += $(lsrc_x86_64)
 
+lsrc_base_aliases   += 	rolling_hash/rolling_hashx_base.c	\
+			rolling_hash/rolling_hash2.c	\
+			rolling_hash/rolling_hash2_base_aliases.c
+
+
+lsrc_aarch64	    += 	rolling_hash/rolling_hashx_base.c	\
+			rolling_hash/rolling_hash2.c	\
+			rolling_hash/rolling_hash2_base_aliases.c
+
 src_include  += -I $(srcdir)/rolling_hash
 extern_hdrs  += include/rolling_hashx.h
 

--- a/rolling_hash/rolling_hash2_base_aliases.c
+++ b/rolling_hash/rolling_hash2_base_aliases.c
@@ -1,0 +1,39 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdint.h>
+uint64_t rolling_hash2_run_until_base(uint32_t * idx, int max_idx, uint64_t * t1,
+				      uint64_t * t2, uint8_t * b1, uint8_t * b2, uint64_t h,
+				      uint64_t mask, uint64_t trigger);
+uint64_t rolling_hash2_run_until(uint32_t * idx, int max_idx, uint64_t * t1,
+				 uint64_t * t2, uint8_t * b1, uint8_t * b2, uint64_t h,
+				 uint64_t mask, uint64_t trigger)
+{
+	return rolling_hash2_run_until_base(idx, max_idx, t1, t2, b1, b2, h, mask, trigger);
+}

--- a/sha1_mb/Makefile.am
+++ b/sha1_mb/Makefile.am
@@ -64,18 +64,13 @@ lsrc_x86_64 += 	sha1_mb/sha1_ni_x1.asm \
 
 lsrc_x86_32 += 	$(lsrc_x86_64)
 
-lsrc_aarch64 += sha1_mb/sha1_ctx_base.c \
+lsrc_aarch64 += sha1_mb/sha1_ctx_base_aliases.c	\
+		sha1_mb/sha1_ctx_base.c \
 		sha1_mb/sha1_ref.c
 
-lsrc_aarch64 += sha1_mb/aarch64/sha1_mb_multibinary.S \
-		sha1_mb/aarch64/sha1_mb_dispatch_init.c  \
-		sha1_mb/aarch64/sha1_ctx_ce.c	\
-		sha1_mb/aarch64/sha1_mb_x1_ce.S		\
-		sha1_mb/aarch64/sha1_mb_x2_ce.S		\
-		sha1_mb/aarch64/sha1_mb_mgr_ce.c
-
-
-lsrc_base_aliases += sha1_mb/sha1_ctx_base_aliases.c
+lsrc_base_aliases += sha1_mb/sha1_ctx_base_aliases.c	\
+		sha1_mb/sha1_ctx_base.c \
+		sha1_mb/sha1_ref.c
 
 src_include += -I $(srcdir)/sha1_mb
 

--- a/sha256_mb/Makefile.am
+++ b/sha256_mb/Makefile.am
@@ -65,7 +65,11 @@ lsrc_x86_64 += 	sha256_mb/sha256_ni_x1.asm \
 
 lsrc_x86_32 += 	$(lsrc_x86_64)
 
-lsrc_aarch64 += sha256_mb/sha256_ctx_base.c
+lsrc_aarch64 += sha256_mb/sha256_ctx_base_aliases.c	\
+		sha256_mb/sha256_ctx_base.c
+
+lsrc_base_aliases += sha256_mb/sha256_ctx_base_aliases.c	\
+		sha256_mb/sha256_ctx_base.c
 
 src_include += -I $(srcdir)/sha256_mb
 

--- a/sha256_mb/sha256_ctx_base_aliases.c
+++ b/sha256_mb/sha256_ctx_base_aliases.c
@@ -1,0 +1,54 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stdint.h>
+#include <string.h>
+#include "sha256_mb.h"
+#include "memcpy_inline.h"
+
+extern void sha256_ctx_mgr_init_base(SHA256_HASH_CTX_MGR * mgr);
+extern SHA256_HASH_CTX *sha256_ctx_mgr_submit_base(SHA256_HASH_CTX_MGR * mgr,
+						   SHA256_HASH_CTX * ctx, const void *buffer,
+						   uint32_t len, HASH_CTX_FLAG flags);
+extern SHA256_HASH_CTX *sha256_ctx_mgr_flush_base(SHA256_HASH_CTX_MGR * mgr);
+
+void sha256_ctx_mgr_init(SHA256_HASH_CTX_MGR * mgr)
+{
+	return sha256_ctx_mgr_init_base(mgr);
+}
+
+SHA256_HASH_CTX *sha256_ctx_mgr_submit(SHA256_HASH_CTX_MGR * mgr, SHA256_HASH_CTX * ctx,
+				       const void *buffer, uint32_t len, HASH_CTX_FLAG flags)
+{
+	return sha256_ctx_mgr_submit_base(mgr, ctx, buffer, len, flags);
+}
+
+SHA256_HASH_CTX *sha256_ctx_mgr_flush(SHA256_HASH_CTX_MGR * mgr)
+{
+	return sha256_ctx_mgr_flush_base(mgr);
+}

--- a/sha512_mb/Makefile.am
+++ b/sha512_mb/Makefile.am
@@ -61,7 +61,11 @@ lsrc_x86_64 += 	sha512_mb/sha512_ctx_avx512.c \
 
 lsrc_x86_32 += 	$(lsrc_x86_64)
 
-lsrc_aarch64 += sha512_mb/sha512_ctx_base.c
+lsrc_aarch64 += sha512_mb/sha512_ctx_base.c	\
+		sha512_mb/sha512_ctx_base_aliases.c
+
+lsrc_base_aliases += sha512_mb/sha512_ctx_base.c	\
+		sha512_mb/sha512_ctx_base_aliases.c
 
 src_include += -I $(srcdir)/sha512_mb
 

--- a/sha512_mb/sha512_ctx_base_aliases.c
+++ b/sha512_mb/sha512_ctx_base_aliases.c
@@ -1,0 +1,54 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stdint.h>
+#include <string.h>
+#include "sha512_mb.h"
+#include "memcpy_inline.h"
+
+extern void sha512_ctx_mgr_init_base(SHA512_HASH_CTX_MGR * mgr);
+extern SHA512_HASH_CTX *sha512_ctx_mgr_submit_base(SHA512_HASH_CTX_MGR * mgr,
+						   SHA512_HASH_CTX * ctx, const void *buffer,
+						   uint32_t len, HASH_CTX_FLAG flags);
+extern SHA512_HASH_CTX *sha512_ctx_mgr_flush_base(SHA512_HASH_CTX_MGR * mgr);
+
+void sha512_ctx_mgr_init(SHA512_HASH_CTX_MGR * mgr)
+{
+	return sha512_ctx_mgr_init_base(mgr);
+}
+
+SHA512_HASH_CTX *sha512_ctx_mgr_submit(SHA512_HASH_CTX_MGR * mgr, SHA512_HASH_CTX * ctx,
+				       const void *buffer, uint32_t len, HASH_CTX_FLAG flags)
+{
+	return sha512_ctx_mgr_submit_base(mgr, ctx, buffer, len, flags);
+}
+
+SHA512_HASH_CTX *sha512_ctx_mgr_flush(SHA512_HASH_CTX_MGR * mgr)
+{
+	return sha512_ctx_mgr_flush_base(mgr);
+}

--- a/sm3_mb/Makefile.am
+++ b/sm3_mb/Makefile.am
@@ -30,6 +30,12 @@
 lsrc_x86_64 += sm3_mb/sm3_ctx_base.c \
 	sm3_mb/sm3_multibinary.asm
 
+lsrc_base_aliases += sm3_mb/sm3_ctx_base.c \
+	sm3_mb/sm3_ctx_base_aliases.c
+
+lsrc_aarch64 += sm3_mb/sm3_ctx_base.c \
+	sm3_mb/sm3_ctx_base_aliases.c
+
 src_include += -I $(srcdir)/sm3_mb
 
 extern_hdrs +=  include/sm3_mb.h \

--- a/sm3_mb/sm3_ctx_base_aliases.c
+++ b/sm3_mb/sm3_ctx_base_aliases.c
@@ -1,0 +1,54 @@
+/**********************************************************************
+  Copyright(c) 2019 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stdint.h>
+#include <string.h>
+#include "sm3_mb.h"
+#include "memcpy_inline.h"
+
+extern void sm3_ctx_mgr_init_base(SM3_HASH_CTX_MGR * mgr);
+extern SM3_HASH_CTX *sm3_ctx_mgr_submit_base(SM3_HASH_CTX_MGR * mgr, SM3_HASH_CTX * ctx,
+					       const void *buffer, uint32_t len,
+					       HASH_CTX_FLAG flags);
+extern SM3_HASH_CTX *sm3_ctx_mgr_flush_base(SM3_HASH_CTX_MGR * mgr);
+
+void sm3_ctx_mgr_init(SM3_HASH_CTX_MGR * mgr)
+{
+	return sm3_ctx_mgr_init_base(mgr);
+}
+
+SM3_HASH_CTX *sm3_ctx_mgr_submit(SM3_HASH_CTX_MGR * mgr, SM3_HASH_CTX * ctx,
+				   const void *buffer, uint32_t len, HASH_CTX_FLAG flags)
+{
+	return sm3_ctx_mgr_submit_base(mgr, ctx, buffer, len, flags);
+}
+
+SM3_HASH_CTX *sm3_ctx_mgr_flush(SM3_HASH_CTX_MGR * mgr)
+{
+	return sm3_ctx_mgr_flush_base(mgr);
+}


### PR DESCRIPTION
This patch is relative with issue #21 .

And non-supported CPU won't build aes code , because there are no AES base function available now . 