### PR TITLE
Fix num_lanes_inuse counting for some algorithms

### DIFF
--- a/md5_mb/md5_mb_mgr_flush_avx.asm
+++ b/md5_mb/md5_mb_mgr_flush_avx.asm
@@ -189,6 +189,7 @@ len_is_0:
 	mov	[state + _unused_lanes], unused_lanes
 
 	mov	dword [state + _lens + 4*idx], 0xFFFFFFFF
+	sub     dword [state + _num_lanes_inuse], 1
 
 	vmovd	xmm0, [state + _args_digest + 4*idx + 0*32]
 	vpinsrd	xmm0, [state + _args_digest + 4*idx + 1*32], 1

--- a/md5_mb/md5_mb_mgr_flush_sse.asm
+++ b/md5_mb/md5_mb_mgr_flush_sse.asm
@@ -190,6 +190,7 @@ len_is_0:
 	mov	[state + _unused_lanes], unused_lanes
 
 	mov	dword [state + _lens + 4*idx], 0xFFFFFFFF
+	sub     dword [state + _num_lanes_inuse], 1
 
 	movd	xmm0, [state + _args_digest + 4*idx + 0*32]
 	pinsrd	xmm0, [state + _args_digest + 4*idx + 1*32], 1

--- a/md5_mb/md5_mb_mgr_submit_avx.asm
+++ b/md5_mb/md5_mb_mgr_submit_avx.asm
@@ -127,6 +127,7 @@ md5_mb_mgr_submit_avx:
         mov     p, [job + _buffer]
         mov     [state + _args_data_ptr + 8*lane], p
 
+	add     dword [state + _num_lanes_inuse], 1
         cmp     unused_lanes, 0xF
         jne     return_null
 
@@ -175,6 +176,7 @@ len_is_0:
         mov     [state + _unused_lanes], unused_lanes
 
 	mov	dword [state + _lens + 4*idx], 0xFFFFFFFF
+	sub     dword [state + _num_lanes_inuse], 1
 
         vmovd    xmm0, [state + _args_digest + 4*idx + 0*32]
         vpinsrd  xmm0, [state + _args_digest + 4*idx + 1*32], 1

--- a/md5_mb/md5_mb_mgr_submit_sse.asm
+++ b/md5_mb/md5_mb_mgr_submit_sse.asm
@@ -127,6 +127,7 @@ md5_mb_mgr_submit_sse:
         mov     p, [job + _buffer]
         mov     [state + _args_data_ptr + 8*lane], p
 
+	add     dword [state + _num_lanes_inuse], 1
         cmp     unused_lanes, 0xF
         jne     return_null
 
@@ -176,6 +177,7 @@ len_is_0:
         mov     [state + _unused_lanes], unused_lanes
 
 	mov	dword [state + _lens + 4*idx], 0xFFFFFFFF
+	sub     dword [state + _num_lanes_inuse], 1
 
         movd    xmm0, [state + _args_digest + 4*idx + 0*32]
         pinsrd  xmm0, [state + _args_digest + 4*idx + 1*32], 1

--- a/sha512_mb/sha512_mb_mgr_flush_avx.asm
+++ b/sha512_mb/sha512_mb_mgr_flush_avx.asm
@@ -170,6 +170,8 @@ len_is_0:
 	or      unused_lanes, idx
 	mov     [state + _unused_lanes], unused_lanes
 
+	sub     dword [state + _num_lanes_inuse], 1
+
 	vmovq    xmm0, [state + _args_digest + 8*idx + 0*32]
 	vpinsrq  xmm0, [state + _args_digest + 8*idx + 1*32], 1
 	vmovq    xmm1, [state + _args_digest + 8*idx + 2*32]

--- a/sha512_mb/sha512_mb_mgr_flush_avx2.asm
+++ b/sha512_mb/sha512_mb_mgr_flush_avx2.asm
@@ -191,6 +191,8 @@ len_is_0:
 	or      unused_lanes, idx
 	mov     [state + _unused_lanes], unused_lanes
 
+	sub     dword [state + _num_lanes_inuse], 1
+
 	vmovq    xmm0, [state + _args_digest + 8*idx + 0*32]
 	vpinsrq  xmm0, [state + _args_digest + 8*idx + 1*32], 1
 	vmovq    xmm1, [state + _args_digest + 8*idx + 2*32]

--- a/sha512_mb/sha512_mb_mgr_flush_sse.asm
+++ b/sha512_mb/sha512_mb_mgr_flush_sse.asm
@@ -172,6 +172,8 @@ len_is_0:
 	or      unused_lanes, idx
 	mov     [state + _unused_lanes], unused_lanes
 
+	sub     dword [state + _num_lanes_inuse], 1
+
 	movq    xmm0, [state + _args_digest + 8*idx + 0*32]
 	pinsrq  xmm0, [state + _args_digest + 8*idx + 1*32], 1
 	movq    xmm1, [state + _args_digest + 8*idx + 2*32]

--- a/sha512_mb/sha512_mb_mgr_submit_avx.asm
+++ b/sha512_mb/sha512_mb_mgr_submit_avx.asm
@@ -159,6 +159,7 @@ sha512_mb_mgr_submit_avx:
 	mov     p, [job + _buffer]
 	mov     [state + _args_data_ptr + 8*lane], p
 
+	add     dword [state + _num_lanes_inuse], 1
 	cmp     unused_lanes, 0xff
 	jne     return_null
 
@@ -201,6 +202,8 @@ len_is_0:
 	shl     unused_lanes, 8
 	or      unused_lanes, idx
 	mov     [state + _unused_lanes], unused_lanes
+
+	sub      dword [state + _num_lanes_inuse], 1
 
 	vmovq    xmm0, [state + _args_digest + 8*idx + 0*32]
 	vpinsrq  xmm0, [state + _args_digest + 8*idx + 1*32], 1

--- a/sha512_mb/sha512_mb_mgr_submit_avx2.asm
+++ b/sha512_mb/sha512_mb_mgr_submit_avx2.asm
@@ -159,6 +159,7 @@ sha512_mb_mgr_submit_avx2:
 	mov     p, [job + _buffer]
 	mov     [state + _args_data_ptr + 8*lane], p
 
+	add     dword [state + _num_lanes_inuse], 1
 	cmp     unused_lanes, 0xff
 	jne     return_null
 
@@ -211,6 +212,8 @@ len_is_0:
 	shl     unused_lanes, 8
 	or      unused_lanes, idx
 	mov     [state + _unused_lanes], unused_lanes
+
+	sub     dword [state + _num_lanes_inuse], 1
 
 	vmovq    xmm0, [state + _args_digest + 8*idx + 0*32]
 	vpinsrq  xmm0, [state + _args_digest + 8*idx + 1*32], 1

--- a/sha512_mb/sha512_mb_mgr_submit_sse.asm
+++ b/sha512_mb/sha512_mb_mgr_submit_sse.asm
@@ -158,6 +158,7 @@ sha512_mb_mgr_submit_sse:
 	mov     p, [job + _buffer]
 	mov     [state + _args_data_ptr + 8*lane], p
 
+	add     dword [state + _num_lanes_inuse], 1
 	cmp     unused_lanes, 0xff
 	jne     return_null
 
@@ -200,6 +201,8 @@ len_is_0:
 	shl     unused_lanes, 8
 	or      unused_lanes, idx
 	mov     [state + _unused_lanes], unused_lanes
+
+	sub     dword [state + _num_lanes_inuse], 1
 
 	movq    xmm0, [state + _args_digest + 8*idx + 0*32]
 	pinsrq  xmm0, [state + _args_digest + 8*idx + 1*32], 1


### PR DESCRIPTION
For multybuffer algorithms md5, sha512 `flush' and `submit' functions
for some cpu features did not increment/decrement num_lanes_inuse field
inside mgr structure. Processing of this field is added to the corresponding
functions.

Signed-off-by: Sergey Kaplun <sergey_v_kaplun@mail.ru>