### PR TITLE
Add support for big-endian architectures

### DIFF
--- a/include/endian_helper.h
+++ b/include/endian_helper.h
@@ -1,0 +1,83 @@
+/**********************************************************************
+  Copyright(c) 2011-2016 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#ifndef _ENDIAN_HELPER_H_
+#define _ENDIAN_HELPER_H_
+
+/**
+ *  @file  endian_helper.h
+ *  @brief Byte order helper routines
+ *
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined (__ICC)
+# define byteswap32(x) _bswap(x)
+# define byteswap64(x) _bswap64(x)
+#elif defined (__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
+# define byteswap32(x) __builtin_bswap32(x)
+# define byteswap64(x) __builtin_bswap64(x)
+#else
+# define byteswap32(x) (  ((x) << 24) \
+                        | (((x) & 0xff00) << 8) \
+                        | (((x) & 0xff0000) >> 8) \
+                        | ((x)>>24))
+# define byteswap64(x) (  (((x) & (0xffull << 0)) << 56) \
+                        | (((x) & (0xffull << 8)) << 40) \
+                        | (((x) & (0xffull << 16)) << 24) \
+                        | (((x) & (0xffull << 24)) << 8) \
+                        | (((x) & (0xffull << 32)) >> 8) \
+                        | (((x) & (0xffull << 40)) >> 24) \
+                        | (((x) & (0xffull << 48)) >> 40) \
+                        | (((x) & (0xffull << 56)) >> 56))
+#endif
+
+// This check works when using GCC (or LLVM).  Assume little-endian
+// if any other compiler is being used.
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) \
+    && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define to_le32(x) byteswap32(x)
+#define to_le64(x) byteswap64(x)
+#define to_be32(x) (x)
+#define to_be64(x) (x)
+#else
+#define to_le32(x) (x)
+#define to_le64(x) (x)
+#define to_be32(x) byteswap32(x)
+#define to_be64(x) byteswap64(x)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _ISA_HELPER_H_

--- a/include/multi_buffer.h
+++ b/include/multi_buffer.h
@@ -40,20 +40,7 @@
 extern "C" {
 #endif
 
-#ifdef __FreeBSD__
-#include <sys/types.h>
-#include <sys/endian.h>
-# define _byteswap_uint64(x) bswap64(x)
-# define _byteswap_ulong(x) bswap32(x)
-#elif defined (__APPLE__)
-#include <libkern/OSByteOrder.h>
-# define _byteswap_uint64(x) OSSwapInt64(x)
-# define _byteswap_ulong(x) OSSwapInt32(x)
-#elif defined (__GNUC__) && !defined (__MINGW32__)
-# include <byteswap.h>
-# define _byteswap_uint64(x) bswap_64(x)
-# define _byteswap_ulong(x) bswap_32(x)
-#endif
+#include "endian_helper.h"
 
 /**
  *  @enum JOB_STS

--- a/md5_mb/md5_ctx_base.c
+++ b/md5_mb/md5_ctx_base.c
@@ -49,7 +49,7 @@
 	if (i < 32) {f = F2(b,c,d); } else \
 	if (i < 48) {f = F3(b,c,d); } else \
 				{f = F4(b,c,d); } \
-	f = a + f + k + w; \
+	f = a + f + k + to_le32(w); \
 	a = b + rol32(f, r);
 
 static void md5_init(MD5_HASH_CTX * ctx, const void *buffer, uint32_t len);
@@ -156,11 +156,6 @@ static void md5_final(MD5_HASH_CTX * ctx, uint32_t remain_len)
 	uint32_t *digest = ctx->job.result_digest;
 
 	ctx->total_length += i;
-	union {
-		uint64_t uint;
-		uint8_t uchar[8];
-	} convert;
-	uint8_t *p;
 	memcpy(buf, buffer, i);
 	buf[i++] = 0x80;
 	for (j = i; j < 120; j++)
@@ -171,16 +166,7 @@ static void md5_final(MD5_HASH_CTX * ctx, uint32_t remain_len)
 	else
 		i = 64;
 
-	convert.uint = 8 * ctx->total_length;
-	p = buf + i - 8;
-	p[7] = convert.uchar[7];
-	p[6] = convert.uchar[6];
-	p[5] = convert.uchar[5];
-	p[4] = convert.uchar[4];
-	p[3] = convert.uchar[3];
-	p[2] = convert.uchar[2];
-	p[1] = convert.uchar[1];
-	p[0] = convert.uchar[0];
+	*(uint64_t *) (buf + i - 8) = to_le64((uint64_t) ctx->total_length * 8);
 
 	md5_single(buf, digest);
 	if (i == 128) {

--- a/md5_mb/md5_mb_rand_ssl_test.c
+++ b/md5_mb/md5_mb_rand_ssl_test.c
@@ -92,11 +92,12 @@ int main(void)
 
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < MD5_DIGEST_NWORDS; j++) {
-			if (ctxpool[i].job.result_digest[j] != ((uint32_t *) digest_ssl[i])[j]) {
+			if (ctxpool[i].job.result_digest[j] !=
+			    to_le32(((uint32_t *) digest_ssl[i])[j])) {
 				fail++;
 				printf("Test%d, digest%d fail %08X <=> %08X\n",
 				       i, j, ctxpool[i].job.result_digest[j],
-				       ((uint32_t *) digest_ssl[i])[j]);
+				       to_le32(((uint32_t *) digest_ssl[i])[j]));
 			}
 		}
 	}
@@ -125,11 +126,11 @@ int main(void)
 		for (i = 0; i < jobs; i++) {
 			for (j = 0; j < MD5_DIGEST_NWORDS; j++) {
 				if (ctxpool[i].job.result_digest[j] !=
-				    ((uint32_t *) digest_ssl[i])[j]) {
+				    to_le32(((uint32_t *) digest_ssl[i])[j])) {
 					fail++;
 					printf("Test%d, digest%d fail %08X <=> %08X\n",
 					       i, j, ctxpool[i].job.result_digest[j],
-					       ((uint32_t *) digest_ssl[i])[j]);
+					       to_le32(((uint32_t *) digest_ssl[i])[j]));
 				}
 			}
 		}

--- a/md5_mb/md5_mb_vs_ossl_perf.c
+++ b/md5_mb/md5_mb_vs_ossl_perf.c
@@ -107,11 +107,12 @@ int main(void)
 
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < MD5_DIGEST_NWORDS; j++) {
-			if (ctxpool[i].job.result_digest[j] != ((uint32_t *) digest_ssl[i])[j]) {
+			if (ctxpool[i].job.result_digest[j] !=
+			    to_le32(((uint32_t *) digest_ssl[i])[j])) {
 				fail++;
 				printf("Test%d, digest%d fail %08X <=> %08X\n",
 				       i, j, ctxpool[i].job.result_digest[j],
-				       ((uint32_t *) digest_ssl[i])[j]);
+				       to_le32(((uint32_t *) digest_ssl[i])[j]));
 			}
 		}
 	}

--- a/md5_mb/md5_ref.c
+++ b/md5_mb/md5_ref.c
@@ -29,6 +29,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include "endian_helper.h"
 
 ////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////
@@ -47,11 +48,6 @@ void md5_ref(uint8_t * input_data, uint32_t * digest, uint32_t len)
 {
 	uint32_t i, j;
 	uint8_t buf[128];
-	union {
-		uint64_t uint;
-		uint8_t uchar[8];
-	} convert;
-	uint8_t *p;
 
 	digest[0] = H0;
 	digest[1] = H1;
@@ -76,16 +72,7 @@ void md5_ref(uint8_t * input_data, uint32_t * digest, uint32_t len)
 	else
 		i = 64;
 
-	convert.uint = 8 * len;
-	p = buf + i - 8;
-	p[7] = convert.uchar[7];
-	p[6] = convert.uchar[6];
-	p[5] = convert.uchar[5];
-	p[4] = convert.uchar[4];
-	p[3] = convert.uchar[3];
-	p[2] = convert.uchar[2];
-	p[1] = convert.uchar[1];
-	p[0] = convert.uchar[0];
+	*(uint64_t *) (buf + i - 8) = to_le64((uint64_t) len * 8);
 
 	md5_single(buf, digest);
 	if (i == 128)
@@ -104,7 +91,7 @@ void md5_ref(uint8_t * input_data, uint32_t * digest, uint32_t len)
 	if (i < 32) {f = F2(b,c,d); } else \
 	if (i < 48) {f = F3(b,c,d); } else \
 				{f = F4(b,c,d); } \
-	f = a + f + k + w; \
+	f = a + f + k + to_le32(w); \
 	a = b + rol32(f, r);
 
 void md5_single(const uint8_t * data, uint32_t digest[4])

--- a/mh_sha1/mh_sha1_block_base.c
+++ b/mh_sha1/mh_sha1_block_base.c
@@ -35,7 +35,7 @@
 // Base multi-hash SHA1 Functions
 ////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////
-#define store_w(s, i, w, ww) (w[i][s] = bswap(ww[i*HASH_SEGS+s]))	// only used for step 0 ~ 15
+#define store_w(s, i, w, ww) (w[i][s] = to_be32(ww[i*HASH_SEGS+s]))	// only used for step 0 ~ 15
 #define update_w(s, i, w) (w[i&15][s] = rol32(w[(i-3)&15][s]^w[(i-8)&15][s]^w[(i-14)&15][s]^w[(i-16)&15][s], 1))	// used for step > 15
 #define update_e_1(s, a, b, c, d, e, i, w)  (e[s] += rol32(a[s],5) + F1(b[s],c[s],d[s]) + K_00_19 + w[i&15][s])
 #define update_e_2(s, a, b, c, d, e, i, w)  (e[s] += rol32(a[s],5) + F2(b[s],c[s],d[s]) + K_20_39 + w[i&15][s])

--- a/mh_sha1/mh_sha1_finalize_base.c
+++ b/mh_sha1/mh_sha1_finalize_base.c
@@ -66,7 +66,7 @@ void MH_SHA1_TAIL_FUNCTION(uint8_t * partial_buffer, uint32_t total_len,
 		memset(partial_buffer, 0, MH_SHA1_BLOCK_SIZE);
 	}
 	//Padding the block
-	len_in_bit = bswap64((uint64_t) total_len * 8);
+	len_in_bit = to_be64((uint64_t) total_len * 8);
 	*(uint64_t *) (partial_buffer + MH_SHA1_BLOCK_SIZE - 8) = len_in_bit;
 	MH_SHA1_BLOCK_FUNCTION(partial_buffer, mh_sha1_segs_digests, frame_buffer, 1);
 

--- a/mh_sha1/mh_sha1_internal.h
+++ b/mh_sha1/mh_sha1_internal.h
@@ -39,6 +39,7 @@
  */
 #include <stdint.h>
 #include "mh_sha1.h"
+#include "endian_helper.h"
 
 #ifdef __cplusplus
  extern "C" {
@@ -73,13 +74,6 @@
 #define F4(b,c,d) (b ^ c ^ d)
 
 #define rol32(x, r) (((x)<<(r)) ^ ((x)>>(32-(r))))
-
-#define bswap(x) (((x)<<24) | (((x)&0xff00)<<8) | (((x)&0xff0000)>>8) | ((x)>>24))
-#define bswap64(x) (((x)<<56) | (((x)&0xff00)<<40) | (((x)&0xff0000)<<24) | \
-		     (((x)&0xff000000)<<8) | (((x)&0xff00000000ull)>>8) | \
-		     (((x)&0xff0000000000ull)<<24) | \
-		     (((x)&0xff000000000000ull)<<40) | \
-		     (((x)&0xff00000000000000ull)<<56))
 
  /*******************************************************************
   * SHA1 API internal function prototypes

--- a/mh_sha1/mh_sha1_ref.c
+++ b/mh_sha1/mh_sha1_ref.c
@@ -45,7 +45,7 @@
 
 #define step00_19(i,a,b,c,d,e) \
 	if (i>15) W(i) = rol32(W(i-3)^W(i-8)^W(i-14)^W(i-16), 1); \
-	else W(i) = bswap(ww[i]); \
+	else W(i) = to_be32(ww[i]); \
 	e += rol32(a,5) + F1(b,c,d) + 0x5A827999 + W(i); \
 	b = rol32(b,30)
 
@@ -171,11 +171,6 @@ void sha1_for_mh_sha1_ref(const uint8_t * input_data, uint32_t * digest, const u
 {
 	uint32_t i, j;
 	uint8_t buf[2 * SHA1_BLOCK_SIZE];
-	union {
-		uint64_t uint;
-		uint8_t uchar[8];
-	} convert;
-	uint8_t *p;
 
 	digest[0] = MH_SHA1_H0;
 	digest[1] = MH_SHA1_H1;
@@ -200,16 +195,7 @@ void sha1_for_mh_sha1_ref(const uint8_t * input_data, uint32_t * digest, const u
 	else
 		i = SHA1_BLOCK_SIZE;
 
-	convert.uint = 8 * len;
-	p = buf + i - 8;
-	p[0] = convert.uchar[7];
-	p[1] = convert.uchar[6];
-	p[2] = convert.uchar[5];
-	p[3] = convert.uchar[4];
-	p[4] = convert.uchar[3];
-	p[5] = convert.uchar[2];
-	p[6] = convert.uchar[1];
-	p[7] = convert.uchar[0];
+	*(uint64_t *) (buf + i - 8) = to_be64((uint64_t) len * 8);
 
 	sha1_single_for_mh_sha1_ref(buf, digest);
 	if (i == (2 * SHA1_BLOCK_SIZE))
@@ -375,7 +361,7 @@ void mh_sha1_tail_ref(uint8_t * partial_buffer, uint32_t total_len,
 		memset(partial_buffer, 0, MH_SHA1_BLOCK_SIZE);
 	}
 	//Padding the block
-	len_in_bit = bswap64((uint64_t) total_len * 8);
+	len_in_bit = to_be64((uint64_t) total_len * 8);
 	*(uint64_t *) (partial_buffer + MH_SHA1_BLOCK_SIZE - 8) = len_in_bit;
 	mh_sha1_block_ref(partial_buffer, mh_sha1_segs_digests, frame_buffer, 1);
 

--- a/mh_sha1/sha1_for_mh_sha1.c
+++ b/mh_sha1/sha1_for_mh_sha1.c
@@ -40,7 +40,7 @@
 
 #define step00_19(i,a,b,c,d,e) \
 	if (i>15) W(i) = rol32(W(i-3)^W(i-8)^W(i-14)^W(i-16), 1); \
-	else W(i) = bswap(ww[i]); \
+	else W(i) = to_be32(ww[i]); \
 	e += rol32(a,5) + F1(b,c,d) + 0x5A827999 + W(i); \
 	b = rol32(b,30)
 
@@ -166,11 +166,6 @@ void sha1_for_mh_sha1(const uint8_t * input_data, uint32_t * digest, const uint3
 {
 	uint32_t i, j;
 	uint8_t buf[2 * SHA1_BLOCK_SIZE];
-	union {
-		uint64_t uint;
-		uint8_t uchar[8];
-	} convert;
-	uint8_t *p;
 
 	digest[0] = MH_SHA1_H0;
 	digest[1] = MH_SHA1_H1;
@@ -195,16 +190,7 @@ void sha1_for_mh_sha1(const uint8_t * input_data, uint32_t * digest, const uint3
 	else
 		i = SHA1_BLOCK_SIZE;
 
-	convert.uint = 8 * len;
-	p = buf + i - 8;
-	p[0] = convert.uchar[7];
-	p[1] = convert.uchar[6];
-	p[2] = convert.uchar[5];
-	p[3] = convert.uchar[4];
-	p[4] = convert.uchar[3];
-	p[5] = convert.uchar[2];
-	p[6] = convert.uchar[1];
-	p[7] = convert.uchar[0];
+	*(uint64_t *) (buf + i - 8) = to_be64((uint64_t) len * 8);
 
 	sha1_single_for_mh_sha1(buf, digest);
 	if (i == (2 * SHA1_BLOCK_SIZE))

--- a/mh_sha256/mh_sha256_block_base.c
+++ b/mh_sha256/mh_sha256_block_base.c
@@ -36,7 +36,7 @@
 ////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////
 // store_w is only used for step 0 ~ 15
-#define store_w(s, i, w, ww) (w[i][s] = bswap(ww[i*HASH_SEGS+s]))
+#define store_w(s, i, w, ww) (w[i][s] = to_be32(ww[i*HASH_SEGS+s]))
 #define Ws(x, s) w[(x) & 15][s]
 // update_w is used for step > 15
 #define update_w(s, i, w) \

--- a/mh_sha256/mh_sha256_finalize_base.c
+++ b/mh_sha256/mh_sha256_finalize_base.c
@@ -67,7 +67,7 @@ void MH_SHA256_TAIL_FUNCTION(uint8_t * partial_buffer, uint32_t total_len,
 		memset(partial_buffer, 0, MH_SHA256_BLOCK_SIZE);
 	}
 	//Padding the block
-	len_in_bit = bswap64((uint64_t) total_len * 8);
+	len_in_bit = to_be64((uint64_t) total_len * 8);
 	*(uint64_t *) (partial_buffer + MH_SHA256_BLOCK_SIZE - 8) = len_in_bit;
 	MH_SHA256_BLOCK_FUNCTION(partial_buffer, mh_sha256_segs_digests, frame_buffer, 1);
 

--- a/mh_sha256/mh_sha256_internal.h
+++ b/mh_sha256/mh_sha256_internal.h
@@ -39,6 +39,7 @@
  */
 #include <stdint.h>
 #include "mh_sha256.h"
+#include "endian_helper.h"
 
 #ifdef __cplusplus
  extern "C" {
@@ -66,13 +67,6 @@
 
  /* mh_sha256 macros */
 #define ror32(x, r) (((x)>>(r)) ^ ((x)<<(32-(r))))
-
-#define bswap(x) (((x)<<24) | (((x)&0xff00)<<8) | (((x)&0xff0000)>>8) | ((x)>>24))
-#define bswap64(x) (((x)<<56) | (((x)&0xff00)<<40) | (((x)&0xff0000)<<24) | \
-		     (((x)&0xff000000)<<8) | (((x)&0xff00000000ull)>>8) | \
-		     (((x)&0xff0000000000ull)<<24) | \
-		     (((x)&0xff000000000000ull)<<40) | \
-		     (((x)&0xff00000000000000ull)<<56))
 
 #define S0(w) (ror32(w,7) ^ ror32(w,18) ^ (w >> 3))
 #define S1(w) (ror32(w,17) ^ ror32(w,19) ^ (w >> 10))

--- a/mh_sha256/mh_sha256_ref.c
+++ b/mh_sha256/mh_sha256_ref.c
@@ -44,7 +44,7 @@
 #define W(x) w[(x) & 15]
 
 #define step(i,a,b,c,d,e,f,g,h,k) \
-	if (i<16) W(i) = bswap(ww[i]); \
+	if (i<16) W(i) = to_be32(ww[i]); \
 	else \
 	W(i) = W(i-16) + S0(W(i-15)) + W(i-7) + S1(W(i-2)); \
 	t2 = s0(a) + maj(a,b,c); \
@@ -147,11 +147,6 @@ void sha256_for_mh_sha256_ref(const uint8_t * input_data, uint32_t * digest,
 {
 	uint32_t i, j;
 	uint8_t buf[2 * SHA256_BLOCK_SIZE];
-	union {
-		uint64_t uint;
-		uint8_t uchar[8];
-	} convert;
-	uint8_t *p;
 
 	digest[0] = MH_SHA256_H0;
 	digest[1] = MH_SHA256_H1;
@@ -179,16 +174,7 @@ void sha256_for_mh_sha256_ref(const uint8_t * input_data, uint32_t * digest,
 	else
 		i = SHA256_BLOCK_SIZE;
 
-	convert.uint = 8 * len;
-	p = buf + i - 8;
-	p[0] = convert.uchar[7];
-	p[1] = convert.uchar[6];
-	p[2] = convert.uchar[5];
-	p[3] = convert.uchar[4];
-	p[4] = convert.uchar[3];
-	p[5] = convert.uchar[2];
-	p[6] = convert.uchar[1];
-	p[7] = convert.uchar[0];
+	*(uint64_t *) (buf + i - 8) = to_be64((uint64_t) len * 8);
 
 	sha256_single_for_mh_sha256_ref(buf, digest);
 	if (i == (2 * SHA256_BLOCK_SIZE))
@@ -354,7 +340,7 @@ void mh_sha256_tail_ref(uint8_t * partial_buffer, uint32_t total_len,
 		memset(partial_buffer, 0, MH_SHA256_BLOCK_SIZE);
 	}
 	//Padding the block
-	len_in_bit = bswap64((uint64_t) total_len * 8);
+	len_in_bit = to_be64((uint64_t) total_len * 8);
 	*(uint64_t *) (partial_buffer + MH_SHA256_BLOCK_SIZE - 8) = len_in_bit;
 	mh_sha256_block_ref(partial_buffer, mh_sha256_segs_digests, frame_buffer, 1);
 

--- a/mh_sha256/sha256_for_mh_sha256.c
+++ b/mh_sha256/sha256_for_mh_sha256.c
@@ -39,7 +39,7 @@
 #define W(x) w[(x) & 15]
 
 #define step(i,a,b,c,d,e,f,g,h,k) \
-	if (i<16) W(i) = bswap(ww[i]); \
+	if (i<16) W(i) = to_be32(ww[i]); \
 	else \
 	W(i) = W(i-16) + S0(W(i-15)) + W(i-7) + S1(W(i-2)); \
 	t2 = s0(a) + maj(a,b,c); \
@@ -141,11 +141,6 @@ void sha256_for_mh_sha256(const uint8_t * input_data, uint32_t * digest, const u
 {
 	uint32_t i, j;
 	uint8_t buf[2 * SHA256_BLOCK_SIZE];
-	union {
-		uint64_t uint;
-		uint8_t uchar[8];
-	} convert;
-	uint8_t *p;
 
 	digest[0] = MH_SHA256_H0;
 	digest[1] = MH_SHA256_H1;
@@ -173,16 +168,7 @@ void sha256_for_mh_sha256(const uint8_t * input_data, uint32_t * digest, const u
 	else
 		i = SHA256_BLOCK_SIZE;
 
-	convert.uint = 8 * len;
-	p = buf + i - 8;
-	p[0] = convert.uchar[7];
-	p[1] = convert.uchar[6];
-	p[2] = convert.uchar[5];
-	p[3] = convert.uchar[4];
-	p[4] = convert.uchar[3];
-	p[5] = convert.uchar[2];
-	p[6] = convert.uchar[1];
-	p[7] = convert.uchar[0];
+	*(uint64_t *) (buf + i - 8) = to_be64((uint64_t) len * 8);
 
 	sha256_single_for_mh_sha256(buf, digest);
 	if (i == (2 * SHA256_BLOCK_SIZE))

--- a/sha1_mb/aarch64/sha1_ctx_ce.c
+++ b/sha1_mb/aarch64/sha1_ctx_ce.c
@@ -229,7 +229,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA1_BLOCK_SIZE * 2], uint64_t 
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA1_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha1_mb/sha1_ctx_avx.c
+++ b/sha1_mb/sha1_ctx_avx.c
@@ -230,7 +230,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA1_BLOCK_SIZE * 2], uint64_t 
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA1_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha1_mb/sha1_ctx_avx2.c
+++ b/sha1_mb/sha1_ctx_avx2.c
@@ -229,7 +229,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA1_BLOCK_SIZE * 2], uint64_t 
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA1_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha1_mb/sha1_ctx_avx512.c
+++ b/sha1_mb/sha1_ctx_avx512.c
@@ -234,7 +234,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA1_BLOCK_SIZE * 2], uint64_t 
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA1_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha1_mb/sha1_ctx_avx512_ni.c
+++ b/sha1_mb/sha1_ctx_avx512_ni.c
@@ -244,7 +244,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA1_BLOCK_SIZE * 2], uint64_t 
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA1_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha1_mb/sha1_ctx_sse.c
+++ b/sha1_mb/sha1_ctx_sse.c
@@ -230,7 +230,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA1_BLOCK_SIZE * 2], uint64_t 
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA1_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha1_mb/sha1_ctx_sse_ni.c
+++ b/sha1_mb/sha1_ctx_sse_ni.c
@@ -236,7 +236,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA1_BLOCK_SIZE * 2], uint64_t 
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA1_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha1_mb/sha1_mb_rand_ssl_test.c
+++ b/sha1_mb/sha1_mb_rand_ssl_test.c
@@ -52,11 +52,6 @@ void rand_buffer(unsigned char *buf, const long buffer_size)
 		buf[i] = rand();
 }
 
-unsigned int byteswap(unsigned int x)
-{
-	return (x >> 24) | (x >> 8 & 0xff00) | (x << 8 & 0xff0000) | (x << 24);
-}
-
 int main(void)
 {
 	SHA1_HASH_CTX_MGR *mgr = NULL;
@@ -98,11 +93,11 @@ int main(void)
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SHA1_DIGEST_NWORDS; j++) {
 			if (ctxpool[i].job.result_digest[j] !=
-			    byteswap(((uint32_t *) digest_ssl[i])[j])) {
+			    to_be32(((uint32_t *) digest_ssl[i])[j])) {
 				fail++;
 				printf("Test%d, digest%d fail %08X <=> %08X\n",
 				       i, j, ctxpool[i].job.result_digest[j],
-				       byteswap(((uint32_t *) digest_ssl[i])[j]));
+				       to_be32(((uint32_t *) digest_ssl[i])[j]));
 			}
 		}
 	}
@@ -131,11 +126,11 @@ int main(void)
 		for (i = 0; i < jobs; i++) {
 			for (j = 0; j < SHA1_DIGEST_NWORDS; j++) {
 				if (ctxpool[i].job.result_digest[j] !=
-				    byteswap(((uint32_t *) digest_ssl[i])[j])) {
+				    to_be32(((uint32_t *) digest_ssl[i])[j])) {
 					fail++;
 					printf("Test%d, digest%d fail %08X <=> %08X\n",
 					       i, j, ctxpool[i].job.result_digest[j],
-					       byteswap(((uint32_t *) digest_ssl[i])[j]));
+					       to_be32(((uint32_t *) digest_ssl[i])[j]));
 				}
 			}
 		}

--- a/sha1_mb/sha1_mb_vs_ossl_perf.c
+++ b/sha1_mb/sha1_mb_vs_ossl_perf.c
@@ -54,11 +54,6 @@
 /* Reference digest global to reduce stack usage */
 static uint8_t digest_ssl[TEST_BUFS][4 * SHA1_DIGEST_NWORDS];
 
-inline unsigned int byteswap32(unsigned int x)
-{
-	return (x >> 24) | (x >> 8 & 0xff00) | (x << 8 & 0xff0000) | (x << 24);
-}
-
 int main(void)
 {
 	SHA1_HASH_CTX_MGR *mgr = NULL;
@@ -112,11 +107,11 @@ int main(void)
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SHA1_DIGEST_NWORDS; j++) {
 			if (ctxpool[i].job.result_digest[j] !=
-			    byteswap32(((uint32_t *) digest_ssl[i])[j])) {
+			    to_be32(((uint32_t *) digest_ssl[i])[j])) {
 				fail++;
 				printf("Test%d, digest%d fail %08X <=> %08X\n",
 				       i, j, ctxpool[i].job.result_digest[j],
-				       byteswap32(((uint32_t *) digest_ssl[i])[j]));
+				       to_be32(((uint32_t *) digest_ssl[i])[j]));
 			}
 		}
 	}

--- a/sha1_mb/sha1_mb_vs_ossl_shortage_perf.c
+++ b/sha1_mb/sha1_mb_vs_ossl_shortage_perf.c
@@ -54,11 +54,6 @@
 /* Reference digest global to reduce stack usage */
 static uint8_t digest_ssl[TEST_BUFS][4 * SHA1_DIGEST_NWORDS];
 
-inline unsigned int byteswap32(unsigned int x)
-{
-	return (x >> 24) | (x >> 8 & 0xff00) | (x << 8 & 0xff0000) | (x << 24);
-}
-
 int main(void)
 {
 	SHA1_HASH_CTX_MGR *mgr = NULL;
@@ -115,11 +110,11 @@ int main(void)
 		for (i = 0; i < nlanes; i++) {
 			for (j = 0; j < SHA1_DIGEST_NWORDS; j++) {
 				if (ctxpool[i].job.result_digest[j] !=
-				    byteswap32(((uint32_t *) digest_ssl[i])[j])) {
+				    to_be32(((uint32_t *) digest_ssl[i])[j])) {
 					fail++;
 					printf("Test%d, digest%d fail %08X <=> %08X\n",
 					       i, j, ctxpool[i].job.result_digest[j],
-					       byteswap32(((uint32_t *) digest_ssl[i])[j]));
+					       to_be32(((uint32_t *) digest_ssl[i])[j]));
 				}
 			}
 		}

--- a/sha256_mb/aarch64/sha256_ctx_ce.c
+++ b/sha256_mb/aarch64/sha256_ctx_ce.c
@@ -235,7 +235,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA256_BLOCK_SIZE * 2], uint64_
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA256_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha256_mb/sha256_ctx_avx.c
+++ b/sha256_mb/sha256_ctx_avx.c
@@ -233,7 +233,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA256_BLOCK_SIZE * 2], uint64_
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA256_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha256_mb/sha256_ctx_avx2.c
+++ b/sha256_mb/sha256_ctx_avx2.c
@@ -233,7 +233,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA256_BLOCK_SIZE * 2], uint64_
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA256_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha256_mb/sha256_ctx_avx512.c
+++ b/sha256_mb/sha256_ctx_avx512.c
@@ -236,7 +236,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA256_BLOCK_SIZE * 2], uint64_
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA256_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha256_mb/sha256_ctx_avx512_ni.c
+++ b/sha256_mb/sha256_ctx_avx512_ni.c
@@ -246,7 +246,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA256_BLOCK_SIZE * 2], uint64_
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA256_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha256_mb/sha256_ctx_base.c
+++ b/sha256_mb/sha256_ctx_base.c
@@ -37,7 +37,6 @@
 #endif
 
 #define ror32(x, r) (((x)>>(r)) ^ ((x)<<(32-(r))))
-#define bswap(x) (((x)<<24) | (((x)&0xff00)<<8) | (((x)&0xff0000)>>8) | ((x)>>24))
 
 #define W(x) w[(x) & 15]
 
@@ -50,7 +49,7 @@
 #define ch(e,f,g) ((e & f) ^ (g & ~e))
 
 #define step(i,a,b,c,d,e,f,g,h,k) \
-	if (i<16) W(i) = bswap(ww[i]); \
+	if (i<16) W(i) = to_be32(ww[i]); \
 	else \
 	W(i) = W(i-16) + S0(W(i-15)) + W(i-7) + S1(W(i-2)); \
 	t2 = s0(a) + maj(a,b,c); \
@@ -161,11 +160,6 @@ static void sha256_final(SHA256_HASH_CTX * ctx, uint32_t remain_len)
 	uint32_t i = remain_len, j;
 	uint8_t buf[2 * SHA256_BLOCK_SIZE];
 	uint32_t *digest = ctx->job.result_digest;
-	union {
-		uint64_t uint;
-		uint8_t uchar[8];
-	} convert;
-	uint8_t *p;
 
 	ctx->total_length += i;
 	memcpy(buf, buffer, i);
@@ -178,16 +172,7 @@ static void sha256_final(SHA256_HASH_CTX * ctx, uint32_t remain_len)
 	else
 		i = SHA256_BLOCK_SIZE;
 
-	convert.uint = 8 * ctx->total_length;
-	p = buf + i - 8;
-	p[0] = convert.uchar[7];
-	p[1] = convert.uchar[6];
-	p[2] = convert.uchar[5];
-	p[3] = convert.uchar[4];
-	p[4] = convert.uchar[3];
-	p[5] = convert.uchar[2];
-	p[6] = convert.uchar[1];
-	p[7] = convert.uchar[0];
+	*(uint64_t *) (buf + i - 8) = to_be64((uint64_t) ctx->total_length * 8);
 
 	sha256_single(buf, digest);
 	if (i == 2 * SHA256_BLOCK_SIZE) {

--- a/sha256_mb/sha256_ctx_sse.c
+++ b/sha256_mb/sha256_ctx_sse.c
@@ -235,7 +235,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA256_BLOCK_SIZE * 2], uint64_
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA256_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha256_mb/sha256_ctx_sse_ni.c
+++ b/sha256_mb/sha256_ctx_sse_ni.c
@@ -239,7 +239,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA256_BLOCK_SIZE * 2], uint64_
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA256_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha256_mb/sha256_mb_rand_ssl_test.c
+++ b/sha256_mb/sha256_mb_rand_ssl_test.c
@@ -52,11 +52,6 @@ void rand_buffer(unsigned char *buf, const long buffer_size)
 		buf[i] = rand();
 }
 
-unsigned int byteswap(unsigned int x)
-{
-	return (x >> 24) | (x >> 8 & 0xff00) | (x << 8 & 0xff0000) | (x << 24);
-}
-
 int main(void)
 {
 	SHA256_HASH_CTX_MGR *mgr = NULL;
@@ -99,11 +94,11 @@ int main(void)
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SHA256_DIGEST_NWORDS; j++) {
 			if (ctxpool[i].job.result_digest[j] !=
-			    byteswap(((uint32_t *) digest_ssl[i])[j])) {
+			    to_be32(((uint32_t *) digest_ssl[i])[j])) {
 				fail++;
 				printf("Test%d, digest%d fail %08X <=> %08X\n",
 				       i, j, ctxpool[i].job.result_digest[j],
-				       byteswap(((uint32_t *) digest_ssl[i])[j]));
+				       to_be32(((uint32_t *) digest_ssl[i])[j]));
 			}
 		}
 	}
@@ -132,11 +127,11 @@ int main(void)
 		for (i = 0; i < jobs; i++) {
 			for (j = 0; j < SHA256_DIGEST_NWORDS; j++) {
 				if (ctxpool[i].job.result_digest[j] !=
-				    byteswap(((uint32_t *) digest_ssl[i])[j])) {
+				    to_be32(((uint32_t *) digest_ssl[i])[j])) {
 					fail++;
 					printf("Test%d, digest%d fail %08X <=> %08X\n",
 					       i, j, ctxpool[i].job.result_digest[j],
-					       byteswap(((uint32_t *) digest_ssl[i])[j]));
+					       to_be32(((uint32_t *) digest_ssl[i])[j]));
 				}
 			}
 		}

--- a/sha256_mb/sha256_mb_vs_ossl_perf.c
+++ b/sha256_mb/sha256_mb_vs_ossl_perf.c
@@ -54,11 +54,6 @@
 /* Reference digest global to reduce stack usage */
 static uint8_t digest_ssl[TEST_BUFS][4 * SHA256_DIGEST_NWORDS];
 
-inline unsigned int byteswap32(unsigned int x)
-{
-	return (x >> 24) | (x >> 8 & 0xff00) | (x << 8 & 0xff0000) | (x << 24);
-}
-
 int main(void)
 {
 	SHA256_HASH_CTX_MGR *mgr = NULL;
@@ -113,11 +108,11 @@ int main(void)
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SHA256_DIGEST_NWORDS; j++) {
 			if (ctxpool[i].job.result_digest[j] !=
-			    byteswap32(((uint32_t *) digest_ssl[i])[j])) {
+			    to_be32(((uint32_t *) digest_ssl[i])[j])) {
 				fail++;
 				printf("Test%d, digest%d fail %08X <=> %08X\n",
 				       i, j, ctxpool[i].job.result_digest[j],
-				       byteswap32(((uint32_t *) digest_ssl[i])[j]));
+				       to_be32(((uint32_t *) digest_ssl[i])[j]));
 			}
 		}
 	}

--- a/sha256_mb/sha256_mb_vs_ossl_shortage_perf.c
+++ b/sha256_mb/sha256_mb_vs_ossl_shortage_perf.c
@@ -54,11 +54,6 @@
 /* Reference digest global to reduce stack usage */
 static uint8_t digest_ssl[TEST_BUFS][4 * SHA256_DIGEST_NWORDS];
 
-inline unsigned int byteswap32(unsigned int x)
-{
-	return (x >> 24) | (x >> 8 & 0xff00) | (x << 8 & 0xff0000) | (x << 24);
-}
-
 int main(void)
 {
 	SHA256_HASH_CTX_MGR *mgr = NULL;
@@ -115,11 +110,11 @@ int main(void)
 		for (i = 0; i < nlanes; i++) {
 			for (j = 0; j < SHA256_DIGEST_NWORDS; j++) {
 				if (ctxpool[i].job.result_digest[j] !=
-				    byteswap32(((uint32_t *) digest_ssl[i])[j])) {
+				    to_be32(((uint32_t *) digest_ssl[i])[j])) {
 					fail++;
 					printf("Test%d, digest%d fail %08X <=> %08X\n",
 					       i, j, ctxpool[i].job.result_digest[j],
-					       byteswap32(((uint32_t *) digest_ssl[i])[j]));
+					       to_be32(((uint32_t *) digest_ssl[i])[j]));
 				}
 			}
 		}

--- a/sha512_mb/aarch64/sha512_ctx_ce.c
+++ b/sha512_mb/aarch64/sha512_ctx_ce.c
@@ -235,7 +235,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA512_BLOCK_SIZE * 2], uint64_
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA512_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha512_mb/sha512_ctx_avx.c
+++ b/sha512_mb/sha512_ctx_avx.c
@@ -234,7 +234,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA512_BLOCK_SIZE * 2], uint64_
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA512_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha512_mb/sha512_ctx_avx2.c
+++ b/sha512_mb/sha512_ctx_avx2.c
@@ -234,7 +234,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA512_BLOCK_SIZE * 2], uint64_
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA512_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha512_mb/sha512_ctx_avx512.c
+++ b/sha512_mb/sha512_ctx_avx512.c
@@ -237,7 +237,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA512_BLOCK_SIZE * 2], uint64_
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA512_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha512_mb/sha512_ctx_base.c
+++ b/sha512_mb/sha512_ctx_base.c
@@ -57,19 +57,10 @@
 #define S0(w) (ror64(w,1) ^ ror64(w,8) ^ (w >> 7))
 #define S1(w) (ror64(w,19) ^ ror64(w,61) ^ (w >> 6))
 
-#define bswap(x)  (((x) & (0xffull << 0)) << 56) \
-		| (((x) & (0xffull << 8)) << 40) \
-		| (((x) & (0xffull <<16)) << 24) \
-		| (((x) & (0xffull <<24)) << 8)  \
-		| (((x) & (0xffull <<32)) >> 8)  \
-		| (((x) & (0xffull <<40)) >> 24) \
-		| (((x) & (0xffull <<48)) >> 40) \
-		| (((x) & (0xffull <<56)) >> 56)
-
 #define W(x) w[(x) & 15]
 
 #define step(i,a,b,c,d,e,f,g,h,k) \
-	if (i<16) W(i) = bswap(ww[i]); \
+	if (i<16) W(i) = to_be64(ww[i]); \
 	else \
 	W(i) = W(i-16) + S0(W(i-15)) + W(i-7) + S1(W(i-2)); \
 	t2 = s0(a) + maj(a,b,c); \
@@ -180,11 +171,6 @@ static void sha512_final(SHA512_HASH_CTX * ctx, uint32_t remain_len)
 	uint32_t i = remain_len, j;
 	uint8_t buf[2 * SHA512_BLOCK_SIZE];
 	uint64_t *digest = ctx->job.result_digest;
-	union {
-		uint64_t uint;
-		uint8_t uchar[8];
-	} convert;
-	uint8_t *p;
 
 	ctx->total_length += i;
 	memcpy(buf, buffer, i);
@@ -197,16 +183,7 @@ static void sha512_final(SHA512_HASH_CTX * ctx, uint32_t remain_len)
 	else
 		i = SHA512_BLOCK_SIZE;
 
-	convert.uint = 8 * ctx->total_length;
-	p = buf + i - 8;
-	p[0] = convert.uchar[7];
-	p[1] = convert.uchar[6];
-	p[2] = convert.uchar[5];
-	p[3] = convert.uchar[4];
-	p[4] = convert.uchar[3];
-	p[5] = convert.uchar[2];
-	p[6] = convert.uchar[1];
-	p[7] = convert.uchar[0];
+	*(uint64_t *) (buf + i - 8) = to_be64((uint64_t) ctx->total_length * 8);
 
 	sha512_single(buf, digest);
 	if (i == 2 * SHA512_BLOCK_SIZE) {

--- a/sha512_mb/sha512_ctx_sb_sse4.c
+++ b/sha512_mb/sha512_ctx_sb_sse4.c
@@ -234,7 +234,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA512_BLOCK_SIZE * 2], uint64_
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA512_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha512_mb/sha512_ctx_sse.c
+++ b/sha512_mb/sha512_ctx_sse.c
@@ -234,7 +234,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SHA512_BLOCK_SIZE * 2], uint64_
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SHA512_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sha512_mb/sha512_mb_rand_ssl_test.c
+++ b/sha512_mb/sha512_mb_rand_ssl_test.c
@@ -52,24 +52,6 @@ void rand_buffer(unsigned char *buf, const long buffer_size)
 		buf[i] = rand();
 }
 
-uint64_t byteswap64(uint64_t x)
-{
-#if defined (__ICC)
-	return _bswap64(x);
-#elif defined (__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
-	return __builtin_bswap64(x);
-#else
-	return (((x & (0xffull << 0)) << 56)
-		| ((x & (0xffull << 8)) << 40)
-		| ((x & (0xffull << 16)) << 24)
-		| ((x & (0xffull << 24)) << 8)
-		| ((x & (0xffull << 32)) >> 8)
-		| ((x & (0xffull << 40)) >> 24)
-		| ((x & (0xffull << 48)) >> 40)
-		| ((x & (0xffull << 56)) >> 56));
-#endif
-}
-
 int main(void)
 {
 	SHA512_HASH_CTX_MGR *mgr = NULL;
@@ -112,11 +94,11 @@ int main(void)
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SHA512_DIGEST_NWORDS; j++) {
 			if (ctxpool[i].job.result_digest[j] !=
-			    byteswap64(((uint64_t *) digest_ssl[i])[j])) {
+			    to_be64(((uint64_t *) digest_ssl[i])[j])) {
 				fail++;
 				printf("Test%d, digest%d fail %016lX <=> %016lX\n",
 				       i, j, ctxpool[i].job.result_digest[j],
-				       byteswap64(((uint64_t *) digest_ssl[i])[j]));
+				       to_be64(((uint64_t *) digest_ssl[i])[j]));
 			}
 		}
 	}
@@ -145,11 +127,11 @@ int main(void)
 		for (i = 0; i < jobs; i++) {
 			for (j = 0; j < SHA512_DIGEST_NWORDS; j++) {
 				if (ctxpool[i].job.result_digest[j] !=
-				    byteswap64(((uint64_t *) digest_ssl[i])[j])) {
+				    to_be64(((uint64_t *) digest_ssl[i])[j])) {
 					fail++;
 					printf("Test%d, digest%d fail %016lX <=> %016lX\n",
 					       i, j, ctxpool[i].job.result_digest[j],
-					       byteswap64(((uint64_t *) digest_ssl[i])[j]));
+					       to_be64(((uint64_t *) digest_ssl[i])[j]));
 				}
 			}
 		}

--- a/sha512_mb/sha512_mb_vs_ossl_perf.c
+++ b/sha512_mb/sha512_mb_vs_ossl_perf.c
@@ -54,24 +54,6 @@
 /* Reference digest global to reduce stack usage */
 static uint8_t digest_ssl[TEST_BUFS][8 * SHA512_DIGEST_NWORDS];
 
-inline uint64_t byteswap64(uint64_t x)
-{
-#if defined (__ICC)
-	return _bswap64(x);
-#elif defined (__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
-	return __builtin_bswap64(x);
-#else
-	return (((x & (0xffull << 0)) << 56)
-		| ((x & (0xffull << 8)) << 40)
-		| ((x & (0xffull << 16)) << 24)
-		| ((x & (0xffull << 24)) << 8)
-		| ((x & (0xffull << 32)) >> 8)
-		| ((x & (0xffull << 40)) >> 24)
-		| ((x & (0xffull << 48)) >> 40)
-		| ((x & (0xffull << 56)) >> 56));
-#endif
-}
-
 int main(void)
 {
 	SHA512_HASH_CTX_MGR *mgr = NULL;
@@ -126,11 +108,11 @@ int main(void)
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SHA512_DIGEST_NWORDS; j++) {
 			if (ctxpool[i].job.result_digest[j] !=
-			    byteswap64(((uint64_t *) digest_ssl[i])[j])) {
+			    to_be64(((uint64_t *) digest_ssl[i])[j])) {
 				fail++;
 				printf("Test%d, digest%d fail %016lX <=> %016lX\n",
 				       i, j, ctxpool[i].job.result_digest[j],
-				       byteswap64(((uint64_t *) digest_ssl[i])[j]));
+				       to_be64(((uint64_t *) digest_ssl[i])[j]));
 			}
 		}
 	}

--- a/sm3_mb/aarch64/sm3_mb_ctx_asimd_aarch64.c
+++ b/sm3_mb/aarch64/sm3_mb_ctx_asimd_aarch64.c
@@ -239,7 +239,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SM3_BLOCK_SIZE * 2], uint64_t t
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SM3_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sm3_mb/aarch64/sm3_mb_ctx_sm_aarch64.c
+++ b/sm3_mb/aarch64/sm3_mb_ctx_sm_aarch64.c
@@ -239,7 +239,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SM3_BLOCK_SIZE * 2], uint64_t t
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SM3_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sm3_mb/sm3_ctx_avx512.c
+++ b/sm3_mb/sm3_ctx_avx512.c
@@ -45,11 +45,6 @@ void sm3_mb_mgr_init_avx512(SM3_MB_JOB_MGR * state);
 SM3_JOB *sm3_mb_mgr_submit_avx512(SM3_MB_JOB_MGR * state, SM3_JOB * job);
 SM3_JOB *sm3_mb_mgr_flush_avx512(SM3_MB_JOB_MGR * state);
 
-static inline uint32_t byteswap32(uint32_t x)
-{
-	return (x >> 24) | (x >> 8 & 0xff00) | (x << 8 & 0xff0000) | (x << 24);
-}
-
 void sm3_mb_mgr_init_avx512(SM3_MB_JOB_MGR * state)
 {
 	unsigned int j;
@@ -227,7 +222,7 @@ static inline uint32_t hash_pad(uint8_t padblock[SM3_BLOCK_SIZE * 2], uint64_t t
 	*((uint64_t *) & padblock[i - 16]) = 0;
 #endif
 
-	*((uint64_t *) & padblock[i - 8]) = _byteswap_uint64((uint64_t) total_len << 3);
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
 
 	return i >> SM3_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
 }

--- a/sm3_mb/sm3_mb_flush_test.c
+++ b/sm3_mb/sm3_mb_flush_test.c
@@ -118,12 +118,13 @@ int main(void)
 
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SM3_DIGEST_NWORDS; j++) {
-			if (ctxpool[i].job.result_digest[j] != ((uint32_t *) digest_ref[i])[j]) {
+			if (ctxpool[i].job.result_digest[j] !=
+			    to_le32(((uint32_t *) digest_ref[i])[j])) {
 				fail++;
 				printf("Test%d fixed size, digest%d "
 				       "fail 0x%08X <=> 0x%08X \n",
 				       i, j, ctxpool[i].job.result_digest[j],
-				       ((uint32_t *) digest_ref[i])[j]);
+				       to_le32(((uint32_t *) digest_ref[i])[j]));
 			}
 		}
 	}

--- a/sm3_mb/sm3_mb_rand_ssl_test.c
+++ b/sm3_mb/sm3_mb_rand_ssl_test.c
@@ -93,11 +93,12 @@ int main(void)
 
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SM3_DIGEST_NWORDS; j++) {
-			if (ctxpool[i].job.result_digest[j] != ((uint32_t *) digest_ssl[i])[j]) {
+			if (ctxpool[i].job.result_digest[j] !=
+			    to_le32(((uint32_t *) digest_ssl[i])[j])) {
 				fail++;
 				printf("Test%d, digest%d fail %08X <=> %08X\n",
 				       i, j, ctxpool[i].job.result_digest[j],
-				       ((uint32_t *) digest_ssl[i])[j]);
+				       to_le32(((uint32_t *) digest_ssl[i])[j]));
 			}
 		}
 	}
@@ -126,11 +127,11 @@ int main(void)
 		for (i = 0; i < jobs; i++) {
 			for (j = 0; j < SM3_DIGEST_NWORDS; j++) {
 				if (ctxpool[i].job.result_digest[j] !=
-				    ((uint32_t *) digest_ssl[i])[j]) {
+				    to_le32(((uint32_t *) digest_ssl[i])[j])) {
 					fail++;
 					printf("Test%d, digest%d fail %08X <=> %08X\n",
 					       i, j, ctxpool[i].job.result_digest[j],
-					       ((uint32_t *) digest_ssl[i])[j]);
+					       to_le32(((uint32_t *) digest_ssl[i])[j]));
 				}
 			}
 		}

--- a/sm3_mb/sm3_mb_rand_test.c
+++ b/sm3_mb/sm3_mb_rand_test.c
@@ -94,12 +94,13 @@ int main(void)
 
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SM3_DIGEST_NWORDS; j++) {
-			if (ctxpool[i].job.result_digest[j] != ((uint32_t *) digest_ref[i])[j]) {
+			if (ctxpool[i].job.result_digest[j] !=
+			    to_le32(((uint32_t *) digest_ref[i])[j])) {
 				fail++;
 				printf("Test%d fixed size, digest%d "
 				       "fail 0x%08X <=> 0x%08X \n",
 				       i, j, ctxpool[i].job.result_digest[j],
-				       ((uint32_t *) digest_ref[i])[j]);
+				       to_le32(((uint32_t *) digest_ref[i])[j]));
 			}
 		}
 	}
@@ -131,12 +132,12 @@ int main(void)
 		for (i = 0; i < jobs; i++) {
 			for (j = 0; j < SM3_DIGEST_NWORDS; j++) {
 				if (ctxpool[i].job.result_digest[j] !=
-				    ((uint32_t *) digest_ref[i])[j]) {
+				    to_le32(((uint32_t *) digest_ref[i])[j])) {
 					fail++;
 					printf("Test%d, digest%d fail "
 					       "0x%08X <=> 0x%08X\n",
 					       i, j, ctxpool[i].job.result_digest[j],
-					       ((uint32_t *) digest_ref[i])[j]);
+					       to_le32(((uint32_t *) digest_ref[i])[j]));
 				}
 			}
 		}
@@ -177,11 +178,12 @@ int main(void)
 
 	for (i = 0; i < jobs; i++) {
 		for (j = 0; j < SM3_DIGEST_NWORDS; j++) {
-			if (ctxpool[i].job.result_digest[j] != ((uint32_t *) digest_ref[i])[j]) {
+			if (ctxpool[i].job.result_digest[j] !=
+			    to_le32(((uint32_t *) digest_ref[i])[j])) {
 				fail++;
 				printf("End test failed at offset %d - result: 0x%08X"
 				       ", ref: 0x%08X\n", i, ctxpool[i].job.result_digest[j],
-				       ((uint32_t *) digest_ref[i])[j]);
+				       to_le32(((uint32_t *) digest_ref[i])[j]));
 			}
 		}
 	}

--- a/sm3_mb/sm3_mb_rand_update_test.c
+++ b/sm3_mb/sm3_mb_rand_update_test.c
@@ -156,11 +156,12 @@ int main(void)
 	// Check digests
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SM3_DIGEST_NWORDS; j++) {
-			if (ctxpool[i].job.result_digest[j] != ((uint32_t *) digest_ref[i])[j]) {
+			if (ctxpool[i].job.result_digest[j] !=
+			    to_le32(((uint32_t *) digest_ref[i])[j])) {
 				fail++;
 				printf("Test%d fixed size, digest%d fail %8X <=> %8X",
 				       i, j, ctxpool[i].job.result_digest[j],
-				       ((uint32_t *) digest_ref[i])[j]);
+				       to_le32(((uint32_t *) digest_ref[i])[j]));
 			}
 		}
 	}
@@ -264,11 +265,11 @@ int main(void)
 		for (i = 0; i < jobs; i++) {
 			for (j = 0; j < SM3_DIGEST_NWORDS; j++) {
 				if (ctxpool[i].job.result_digest[j] !=
-				    ((uint32_t *) digest_ref[i])[j]) {
+				    to_le32(((uint32_t *) digest_ref[i])[j])) {
 					fail++;
 					printf("Test%d, digest%d fail %8X <=> %8X\n",
 					       i, j, ctxpool[i].job.result_digest[j],
-					       ((uint32_t *) digest_ref[i])[j]);
+					       to_le32(((uint32_t *) digest_ref[i])[j]));
 				}
 			}
 		}

--- a/sm3_mb/sm3_mb_vs_ossl_perf.c
+++ b/sm3_mb/sm3_mb_vs_ossl_perf.c
@@ -106,11 +106,12 @@ int main(void)
 
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SM3_DIGEST_NWORDS; j++) {
-			if (ctxpool[i].job.result_digest[j] != ((uint32_t *) digest_ssl[i])[j]) {
+			if (ctxpool[i].job.result_digest[j] !=
+			    to_le32(((uint32_t *) digest_ssl[i])[j])) {
 				fail++;
 				printf("Test%d, digest%d fail %08X <=> %08X\n",
 				       i, j, ctxpool[i].job.result_digest[j],
-				       ((uint32_t *) digest_ssl[i])[j]);
+				       to_le32(((uint32_t *) digest_ssl[i])[j]));
 			}
 		}
 	}

--- a/sm3_mb/sm3_mb_vs_ossl_shortage_perf.c
+++ b/sm3_mb/sm3_mb_vs_ossl_shortage_perf.c
@@ -111,11 +111,11 @@ int main(void)
 		for (i = 0; i < nlanes; i++) {
 			for (j = 0; j < SM3_DIGEST_NWORDS; j++) {
 				if (ctxpool[i].job.result_digest[j] !=
-				    ((uint32_t *) digest_ssl[i])[j]) {
+				    to_le32(((uint32_t *) digest_ssl[i])[j])) {
 					fail++;
 					printf("Test%d, digest%d fail %08X <=> %08X\n",
 					       i, j, ctxpool[i].job.result_digest[j],
-					       ((uint32_t *) digest_ssl[i])[j]);
+					       to_le32(((uint32_t *) digest_ssl[i])[j]));
 				}
 			}
 		}

--- a/sm3_mb/sm3_ref_test.c
+++ b/sm3_mb/sm3_ref_test.c
@@ -58,11 +58,6 @@ static uint32_t *exp_result_digest[MSGS] = {
 	exp_result_digest1, exp_result_digest2
 };
 
-static inline uint32_t byteswap32(uint32_t x)
-{
-	return (x >> 24) | (x >> 8 & 0xff00) | (x << 8 & 0xff0000) | (x << 24);
-}
-
 int main(void)
 {
 	SM3_HASH_CTX_MGR *mgr = NULL;

--- a/tests/extended/md5_mb_over_4GB_test.c
+++ b/tests/extended/md5_mb_over_4GB_test.c
@@ -129,13 +129,13 @@ int main(void)
 
 	printf("openssl md5 update digest: \n");
 	for (i = 0; i < MD5_DIGEST_NWORDS; i++)
-		printf("%08X - ", ((uint32_t *) digest_ref_upd)[i]);
+		printf("%08X - ", to_le32(((uint32_t *) digest_ref_upd)[i]));
 	printf("\n");
 
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < MD5_DIGEST_NWORDS; j++) {
 			if (ctxpool[i].job.result_digest[j] !=
-			    ((uint32_t *) digest_ref_upd)[j]) {
+			    to_le32(((uint32_t *) digest_ref_upd)[j])) {
 				fail++;
 			}
 		}

--- a/tests/extended/sha1_mb_over_4GB_test.c
+++ b/tests/extended/sha1_mb_over_4GB_test.c
@@ -40,11 +40,6 @@
 /* Reference digest global to reduce stack usage */
 static uint8_t digest_ref_upd[4 * SHA1_DIGEST_NWORDS];
 
-inline static unsigned int byteswap32(unsigned int x)
-{
-	return (x >> 24) | (x >> 8 & 0xff00) | (x << 8 & 0xff0000) | (x << 24);
-}
-
 struct user_data {
 	int idx;
 	uint64_t processed;
@@ -134,13 +129,13 @@ int main(void)
 
 	printf("openssl SHA1 update digest: \n");
 	for (i = 0; i < SHA1_DIGEST_NWORDS; i++)
-		printf("%08X - ", byteswap32(((uint32_t *) digest_ref_upd)[i]));
+		printf("%08X - ", to_be32(((uint32_t *) digest_ref_upd)[i]));
 	printf("\n");
 
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SHA1_DIGEST_NWORDS; j++) {
 			if (ctxpool[i].job.result_digest[j] !=
-			    byteswap32(((uint32_t *) digest_ref_upd)[j])) {
+			    to_be32(((uint32_t *) digest_ref_upd)[j])) {
 				fail++;
 			}
 		}

--- a/tests/extended/sha256_mb_over_4GB_test.c
+++ b/tests/extended/sha256_mb_over_4GB_test.c
@@ -40,11 +40,6 @@
 /* Reference digest global to reduce stack usage */
 static uint8_t digest_ref_upd[4 * SHA256_DIGEST_NWORDS];
 
-static inline unsigned int byteswap32(unsigned int x)
-{
-	return (x >> 24) | (x >> 8 & 0xff00) | (x << 8 & 0xff0000) | (x << 24);
-}
-
 struct user_data {
 	int idx;
 	uint64_t processed;
@@ -134,13 +129,13 @@ int main(void)
 
 	printf("openssl SHA256 update digest: \n");
 	for (i = 0; i < SHA256_DIGEST_NWORDS; i++)
-		printf("%08X - ", byteswap32(((uint32_t *) digest_ref_upd)[i]));
+		printf("%08X - ", to_be32(((uint32_t *) digest_ref_upd)[i]));
 	printf("\n");
 
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SHA256_DIGEST_NWORDS; j++) {
 			if (ctxpool[i].job.result_digest[j] !=
-			    byteswap32(((uint32_t *) digest_ref_upd)[j])) {
+			    to_be32(((uint32_t *) digest_ref_upd)[j])) {
 				fail++;
 			}
 		}

--- a/tests/extended/sha512_mb_over_4GB_test.c
+++ b/tests/extended/sha512_mb_over_4GB_test.c
@@ -40,24 +40,6 @@
 /* Reference digest global to reduce stack usage */
 static uint8_t digest_ref_upd[8 * SHA512_DIGEST_NWORDS];
 
-inline static uint64_t byteswap64(uint64_t x)
-{
-#if defined (__ICC)
-	return _bswap64(x);
-#elif defined (__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
-	return __builtin_bswap64(x);
-#else
-	return (((x & (0xffull << 0)) << 56)
-		| ((x & (0xffull << 8)) << 40)
-		| ((x & (0xffull << 16)) << 24)
-		| ((x & (0xffull << 24)) << 8)
-		| ((x & (0xffull << 32)) >> 8)
-		| ((x & (0xffull << 40)) >> 24)
-		| ((x & (0xffull << 48)) >> 40)
-		| ((x & (0xffull << 56)) >> 56));
-#endif
-}
-
 struct user_data {
 	int idx;
 	uint64_t processed;
@@ -147,13 +129,13 @@ int main(void)
 
 	printf("openssl sha512 update digest: \n");
 	for (i = 0; i < SHA512_DIGEST_NWORDS; i++)
-		printf("%016lX - ", byteswap64(((uint64_t *) digest_ref_upd)[i]));
+		printf("%016lX - ", to_be64(((uint64_t *) digest_ref_upd)[i]));
 	printf("\n");
 
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SHA512_DIGEST_NWORDS; j++) {
 			if (ctxpool[i].job.result_digest[j] !=
-			    byteswap64(((uint64_t *) digest_ref_upd)[j])) {
+			    to_be64(((uint64_t *) digest_ref_upd)[j])) {
 				fail++;
 			}
 		}

--- a/tests/extended/sm3_mb_over_4GB_test.c
+++ b/tests/extended/sm3_mb_over_4GB_test.c
@@ -135,13 +135,13 @@ int main(void)
 
 	printf("openssl SM3 update digest: \n");
 	for (i = 0; i < SM3_DIGEST_NWORDS; i++)
-		printf("%08X - ", ((uint32_t *) digest_ref_upd)[i]);
+		printf("%08X - ", to_le32(((uint32_t *) digest_ref_upd)[i]));
 	printf("\n");
 
 	for (i = 0; i < TEST_BUFS; i++) {
 		for (j = 0; j < SM3_DIGEST_NWORDS; j++) {
 			if (ctxpool[i].job.result_digest[j] !=
-			    ((uint32_t *) digest_ref_upd)[j]) {
+			    to_le32(((uint32_t *) digest_ref_upd)[j])) {
 				fail++;
 			}
 		}


### PR DESCRIPTION
Create a new header endian_helper.h as a central place for
byte-swap and endian helper routines:
  - byteswap32 / byteswap64
  - to_le32 / to_le64
  - to_be32 / to_be64

Replace all existing byte-swap routines throughout the code
base by the appropriate endian helper routine.  Usually, this
is to_be32 / to_be64, but in a few places in sm3_mb we need to
swap unconditionally to convert the internal big-endian digest
to the externally expected little-endian digest format.

Finally, add the required to_le32 / to_le64 calls in places
where byte-swaps were missing, but are required on big-endian
machines.

Signed-off-by: Ulrich Weigand <ulrich.weigand@de.ibm.com>