### PR TITLE
Release mgr with aligned_free

### DIFF
--- a/examples/saturation_test/md5_thread.c
+++ b/examples/saturation_test/md5_thread.c
@@ -197,7 +197,7 @@ void *MB_THREAD_FUNC(void *arg)
 
       out:
 	free(ctxpool);
-	free(mgr);
+	aligned_free(mgr);
 	for (j = 0; j < rounds_buf; j++) {
 		free(carry_buf[j]);
 		free(digests[j]);


### PR DESCRIPTION
mgr is allocated with _aligned_malloc and released with free instead of aligned_free