### PR TITLE
Update comments: correct some typos

### DIFF
--- a/aes/gcm_nt_rand_test.c
+++ b/aes/gcm_nt_rand_test.c
@@ -981,7 +981,7 @@ int test_gcm_strm_efence(void)
 		if (test.Plen + offset != 0) {
 			posix_memalign((void **)&test.P, 64, test.Plen + offset);
 			posix_memalign((void **)&test.C, 64, test.Plen + offset);
-		} else {	//This else clause is here becuase openssl 1.0.1k does not handle NULL pointers
+		} else {	//This else clause is here because openssl 1.0.1k does not handle NULL pointers
 			posix_memalign((void **)&test.P, 64, 16);
 			posix_memalign((void **)&test.C, 64, 16);
 		}
@@ -1076,7 +1076,7 @@ int test_gcm_strm_combinations(int test_len)
 		if (test.Plen + offset != 0) {
 			posix_memalign((void **)&test.P, 64, test.Plen + offset);
 			posix_memalign((void **)&test.C, 64, test.Plen + offset);
-		} else {	//This else clause is here becuase openssl 1.0.1k does not handle NULL pointers
+		} else {	//This else clause is here because openssl 1.0.1k does not handle NULL pointers
 			posix_memalign((void **)&test.P, 64, 16);
 			posix_memalign((void **)&test.C, 64, 16);
 		}
@@ -1169,7 +1169,7 @@ int test_gcm_combinations(void)
 		if (test.Plen + offset != 0) {
 			posix_memalign((void **)&test.P, 64, test.Plen + offset);
 			posix_memalign((void **)&test.C, 64, test.Plen + offset);
-		} else {	//This else clause is here becuase openssl 1.0.1k does not handle NULL pointers
+		} else {	//This else clause is here because openssl 1.0.1k does not handle NULL pointers
 			posix_memalign((void **)&test.P, 64, 16);
 			posix_memalign((void **)&test.C, 64, 16);
 		}
@@ -1262,7 +1262,7 @@ int test_gcm256_combinations(void)
 		if (test.Plen + offset != 0) {
 			posix_memalign((void **)&test.P, 64, test.Plen + offset);
 			posix_memalign((void **)&test.C, 64, test.Plen + offset);
-		} else {	//This else clause is here becuase openssl 1.0.1k does not handle NULL pointers
+		} else {	//This else clause is here because openssl 1.0.1k does not handle NULL pointers
 			posix_memalign((void **)&test.P, 64, 16);
 			posix_memalign((void **)&test.C, 64, 16);
 		}
@@ -1358,7 +1358,7 @@ int test_gcm256_strm_combinations(int test_len)
 		if (test.Plen + offset != 0) {
 			posix_memalign((void **)&test.P, 64, test.Plen + offset);
 			posix_memalign((void **)&test.C, 64, test.Plen + offset);
-		} else {	//This else clause is here becuase openssl 1.0.1k does not handle NULL pointers
+		} else {	//This else clause is here because openssl 1.0.1k does not handle NULL pointers
 			posix_memalign((void **)&test.P, 64, 16);
 			posix_memalign((void **)&test.C, 64, 16);
 		}
@@ -1852,7 +1852,7 @@ int test_gcm_strm_combinations2(int length, int start, int breaks)
 		if (test.Plen + offset != 0) {
 			posix_memalign((void **)&test.P, 64, test.Plen + offset);
 			posix_memalign((void **)&test.C, 64, test.Plen + offset);
-		} else {	//This else clause is here becuase openssl 1.0.1k does not handle NULL pointers
+		} else {	//This else clause is here because openssl 1.0.1k does not handle NULL pointers
 			posix_memalign((void **)&test.P, 64, 16);
 			posix_memalign((void **)&test.C, 64, 16);
 		}

--- a/aes/gcm_ossl_perf.c
+++ b/aes/gcm_ossl_perf.c
@@ -95,7 +95,7 @@ void aes_gcm_perf(void)
 	int i;
 
 	printf
-	    ("AES GCM performace parameters plain text length:%d; IV length:%d; ADD length:%d \n",
+	    ("AES GCM performance parameters plain text length:%d; IV length:%d; ADD length:%d \n",
 	     TEST_LEN, GCM_IV_LEN, AAD_LENGTH);
 
 	mk_rand_data(key128, sizeof(key128));

--- a/aes/gcm_std_vectors_random_test.c
+++ b/aes/gcm_std_vectors_random_test.c
@@ -987,7 +987,7 @@ int test_gcm_strm_efence(void)
 		if (test.Plen + offset != 0) {
 			test.P = malloc(test.Plen + offset);
 			test.C = malloc(test.Plen + offset);
-		} else {	//This else clause is here becuase openssl 1.0.1k does not handle NULL pointers
+		} else {	//This else clause is here because openssl 1.0.1k does not handle NULL pointers
 			test.P = malloc(16);
 			test.C = malloc(16);
 		}
@@ -1082,7 +1082,7 @@ int test_gcm_strm_combinations(int test_len)
 		if (test.Plen + offset != 0) {
 			test.P = malloc(test.Plen + offset);
 			test.C = malloc(test.Plen + offset);
-		} else {	//This else clause is here becuase openssl 1.0.1k does not handle NULL pointers
+		} else {	//This else clause is here because openssl 1.0.1k does not handle NULL pointers
 			test.P = malloc(16);
 			test.C = malloc(16);
 		}
@@ -1175,7 +1175,7 @@ int test_gcm_combinations(void)
 		if (test.Plen + offset != 0) {
 			test.P = malloc(test.Plen + offset);
 			test.C = malloc(test.Plen + offset);
-		} else {	//This else clause is here becuase openssl 1.0.1k does not handle NULL pointers
+		} else {	//This else clause is here because openssl 1.0.1k does not handle NULL pointers
 			test.P = malloc(16);
 			test.C = malloc(16);
 		}
@@ -1268,7 +1268,7 @@ int test_gcm256_combinations(void)
 		if (test.Plen + offset != 0) {
 			test.P = malloc(test.Plen + offset);
 			test.C = malloc(test.Plen + offset);
-		} else {	//This else clause is here becuase openssl 1.0.1k does not handle NULL pointers
+		} else {	//This else clause is here because openssl 1.0.1k does not handle NULL pointers
 			test.P = malloc(16);
 			test.C = malloc(16);
 		}
@@ -1364,7 +1364,7 @@ int test_gcm256_strm_combinations(int test_len)
 		if (test.Plen + offset != 0) {
 			test.P = malloc(test.Plen + offset);
 			test.C = malloc(test.Plen + offset);
-		} else {	//This else clause is here becuase openssl 1.0.1k does not handle NULL pointers
+		} else {	//This else clause is here because openssl 1.0.1k does not handle NULL pointers
 			test.P = malloc(16);
 			test.C = malloc(16);
 		}
@@ -1848,7 +1848,7 @@ int test_gcm_strm_combinations2(int length, int start, int breaks)
 		if (test.Plen + offset != 0) {
 			test.P = malloc(test.Plen + offset);
 			test.C = malloc(test.Plen + offset);
-		} else {	//This else clause is here becuase openssl 1.0.1k does not handle NULL pointers
+		} else {	//This else clause is here because openssl 1.0.1k does not handle NULL pointers
 			test.P = malloc(16);
 			test.C = malloc(16);
 		}

--- a/aes/gcm_std_vectors_test.c
+++ b/aes/gcm_std_vectors_test.c
@@ -298,7 +298,7 @@ void aes_gcm_stream_dec_128(const struct gcm_key_data *key_data,
 			    uint64_t aad_len, uint8_t * auth_tag, uint64_t auth_tag_len)
 {
 	aes_gcm_init_128(key_data, context, iv, aad, aad_len);
-	uint8_t test_sequence[] = { 1, 12, 22, 0, 1, 12, 16 };	//sum(test_sequence) > max_Plen in verctors
+	uint8_t test_sequence[] = { 1, 12, 22, 0, 1, 12, 16 };	//sum(test_sequence) > max_Plen in vectors
 	uint32_t i;
 	uint32_t offset = 0, dist;
 
@@ -427,7 +427,7 @@ void aes_gcm_stream_enc_256(const struct gcm_key_data *key_data,
 			    uint64_t aad_len, uint8_t * auth_tag, uint64_t auth_tag_len)
 {
 	aes_gcm_init_256(key_data, context, iv, aad, aad_len);
-	uint8_t test_sequence[] = { 1, 12, 22, 0, 1, 12, 16 };	//sum(test_sequence) > max_Plen in verctors
+	uint8_t test_sequence[] = { 1, 12, 22, 0, 1, 12, 16 };	//sum(test_sequence) > max_Plen in vectors
 	uint32_t i;
 	uint32_t offset = 0, dist;
 
@@ -454,7 +454,7 @@ void aes_gcm_stream_dec_256(const struct gcm_key_data *key_data,
 			    uint64_t aad_len, uint8_t * auth_tag, uint64_t auth_tag_len)
 {
 	aes_gcm_init_256(key_data, context, iv, aad, aad_len);
-	uint8_t test_sequence[] = { 1, 12, 22, 0, 1, 12, 16 };	//sum(test_sequence) > max_Plen in verctors
+	uint8_t test_sequence[] = { 1, 12, 22, 0, 1, 12, 16 };	//sum(test_sequence) > max_Plen in vectors
 	uint32_t i;
 	uint32_t offset = 0, dist;
 

--- a/aes/gcm_vectors.h
+++ b/aes/gcm_vectors.h
@@ -47,7 +47,7 @@ typedef struct gcm_vector {
 	uint64_t       Plen;       // length of our plaintext
 	//outputs of encryption
 	uint8_t*       C;          // same length as PT
-	uint8_t*       T;          // Authenication tag
+	uint8_t*       T;          // Authentication tag
 	uint8_t        Tlen;       // AT length can be 0 to 128bits
 } gcm_vector;
 

--- a/examples/saturation_test/isal_multithread_perf.c
+++ b/examples/saturation_test/isal_multithread_perf.c
@@ -2,7 +2,7 @@
  * @file isal_multithread_perf.c
  * @brief It is used to verify high speed algorithm saturation issue
  * @details
- *	usage: taskset -c <cpu_indexs1,cpu_index2,...> isal_multithread_perf -m <algorithm name> -n <thread num>
+ *	usage: taskset -c <cpu_index1,cpu_index2,...> isal_multithread_perf -m <algorithm name> -n <thread num>
  *	eg: taskset -c 0-9,20-29 ./isal_multithread_perf -m md5_mb -n 10
  */
 

--- a/md5_mb/md5_mb_rand_ssl_test.c
+++ b/md5_mb/md5_mb_rand_ssl_test.c
@@ -111,7 +111,7 @@ int main(void)
 		md5_ctx_mgr_init(mgr);
 
 		for (i = 0; i < jobs; i++) {
-			// Ramdom buffer with ramdom len and contents
+			// Random buffer with random len and contents
 			lens[i] = rand() % (TEST_LEN);
 			rand_buffer(bufs[i], lens[i]);
 

--- a/sha1_mb/sha1_ctx_avx512_ni.c
+++ b/sha1_mb/sha1_ctx_avx512_ni.c
@@ -37,10 +37,10 @@
 #endif
 
 /**
- *  sha1_ctx_avx512_ni related functions are aiming to utilize Canonlake.
+ *  sha1_ctx_avx512_ni related functions are aiming to utilize Canon Lake.
  *  Since SHANI is still slower than multibuffer for full lanes,
  *  sha1_ctx_mgr_init_avx512_ni and sha1_ctx_mgr_submit_avx512_ni are
- *  similare with their avx512 versions.
+ *  similar with their avx512 versions.
  *  sha1_ctx_mgr_flush_avx512_ni is different. It will call
  *  sha1_mb_mgr_flush_avx512_ni which would use shani when lanes are less
  *  than a threshold.

--- a/sha1_mb/sha1_mb_rand_ssl_test.c
+++ b/sha1_mb/sha1_mb_rand_ssl_test.c
@@ -111,7 +111,7 @@ int main(void)
 		sha1_ctx_mgr_init(mgr);
 
 		for (i = 0; i < jobs; i++) {
-			// Ramdom buffer with ramdom len and contents
+			// Random buffer with random len and contents
 			lens[i] = rand() % (TEST_LEN);
 			rand_buffer(bufs[i], lens[i]);
 

--- a/sha256_mb/sha256_ctx_avx512_ni.c
+++ b/sha256_mb/sha256_ctx_avx512_ni.c
@@ -37,7 +37,7 @@
 #endif
 
 /**
- *  sha256_ctx_avx512_ni related functions are aiming to utilize Canonlake.
+ *  sha256_ctx_avx512_ni related functions are aiming to utilize Canon Lake.
  *  Since SHANI is still slower than multibuffer for full lanes,
  *  sha256_ctx_mgr_init_avx512_ni and sha256_ctx_mgr_submit_avx512_ni are
  *  similare with their avx512 versions.

--- a/sha256_mb/sha256_mb_rand_ssl_test.c
+++ b/sha256_mb/sha256_mb_rand_ssl_test.c
@@ -112,7 +112,7 @@ int main(void)
 		sha256_ctx_mgr_init(mgr);
 
 		for (i = 0; i < jobs; i++) {
-			// Ramdom buffer with ramdom len and contents
+			// Random buffer with random len and contents
 			lens[i] = rand() % (TEST_LEN);
 			rand_buffer(bufs[i], lens[i]);
 

--- a/sha512_mb/sha512_mb_rand_ssl_test.c
+++ b/sha512_mb/sha512_mb_rand_ssl_test.c
@@ -112,7 +112,7 @@ int main(void)
 		sha512_ctx_mgr_init(mgr);
 
 		for (i = 0; i < jobs; i++) {
-			// Ramdom buffer with ramdom len and contents
+			// Random buffer with random len and contents
 			lens[i] = rand() % (TEST_LEN);
 			rand_buffer(bufs[i], lens[i]);
 

--- a/sm3_mb/sm3_mb_rand_ssl_test.c
+++ b/sm3_mb/sm3_mb_rand_ssl_test.c
@@ -112,7 +112,7 @@ int main(void)
 		sm3_ctx_mgr_init(mgr);
 
 		for (i = 0; i < jobs; i++) {
-			// Ramdom buffer with ramdom len and contents
+			// Random buffer with random len and contents
 			lens[i] = rand() % (TEST_LEN);
 			rand_buffer(bufs[i], lens[i]);
 


### PR DESCRIPTION
Updated some comments while reading the library.

17 typos are corrected, such as:

```
"becuase" to "because"

"performace" to "performance"

"verctor" to "vector"

"ramdom" to "random"
```