### PR TITLE
Optimization of mh-sha1-murmur3 for aarch64 by ASIMD

### DIFF
--- a/mh_sha1/aarch64/mh_sha1_block_asimd.S
+++ b/mh_sha1/aarch64/mh_sha1_block_asimd.S
@@ -29,114 +29,11 @@
 
 	.arch armv8-a
 
-.macro  declare_var_vector_reg name:req,reg:req
-	\name	.req      v\reg
-.endm
+#include "sha1_asimd_common.S"
 
-/* macro F = (D ^ (B & (C ^ D))) */
-.macro FUNC_F0 reg_f:req,reg_b:req,reg_c:req,reg_d:req
-	eor	\reg_f\().16b, \reg_c\().16b, \reg_d\().16b
-	and	\reg_f\().16b, \reg_b\().16b, \reg_f\().16b
-	eor	\reg_f\().16b, \reg_d\().16b, \reg_f\().16b
-.endm
-
-/* F = (B ^ C ^ D) */
-.macro FUNC_F1 reg_f:req,reg_b:req,reg_c:req,reg_d:req
-	eor	\reg_f\().16b, \reg_b\().16b, \reg_c\().16b
-	eor	\reg_f\().16b, \reg_f\().16b, \reg_d\().16b
-.endm
-
-/* F = ((B & C) | (B & D) | (C & D)) */
-.macro FUNC_F2 reg_f:req,reg_b:req,reg_c:req,reg_d:req
-	and	vT0.16b, \reg_b\().16b, \reg_c\().16b
-	and	vT1.16b, \reg_b\().16b, \reg_d\().16b
-	and	vT2.16b, \reg_c\().16b, \reg_d\().16b
-	orr	\reg_f\().16b, vT0.16b, vT1.16b
-	orr	\reg_f\().16b, \reg_f\().16b, vT2.16b
-.endm
-
-/* F = (B ^ C ^ D) */
-.macro FUNC_F3 reg_f:req,reg_b:req,reg_c:req,reg_d:req
-	FUNC_F1	\reg_f,\reg_b,\reg_c,\reg_d
-.endm
-
-.macro SHA1_STEP_00_15 reg_a:req,reg_b:req,reg_c:req,reg_d:req,reg_e:req,reg_f:req,windex:req,reg_k:req,data:req,func_f:req,reg_t:req
-	// e = (a leftrotate 5) + f + e + k + w[i]
-	ushr	\reg_t\().4s, \reg_a\().4s, 32 - 5
-	add	\reg_e\().4s, \reg_e\().4s, \reg_k\().4s
-	add	tmp, \data, (\windex * 16)
-	ld1	{\reg_f\().4s}, [tmp]
-	sli	\reg_t\().4s, \reg_a\().4s, 5
-	add	\reg_e\().4s, \reg_e\().4s, \reg_f\().4s
-	add	\reg_e\().4s, \reg_e\().4s, \reg_t\().4s
-	ushr	\reg_t\().4s, \reg_b\().4s, 32 - 30
-	\func_f	\reg_f\(), \reg_b\(), \reg_c\(), \reg_d\()
-	add	\reg_e\().4s, \reg_e\().4s, \reg_f\().4s
-	sli	\reg_t\().4s, \reg_b\().4s, 30
-	mov	\reg_b\().16b, \reg_t\().16b
-.endm
-
-.macro SHA1_STEP_16_79 reg_a:req,reg_b:req,reg_c:req,reg_d:req,reg_e:req,reg_f:req,windex:req,reg_k:req,data:req,func_f:req,reg_t:req
-	/* w[i] = (w[i-3] xor w[i-8] xor w[i-14] xor w[i-16]) leftrotate 1 */
-	add	tmp, \data, #(((\windex - 14) & 15) * 16)
-	ld1	{vT1.4s}, [tmp]
-	add	tmp, \data, #(((\windex - 8) & 15) * 16)
-	ld1	{vT2.4s}, [tmp]
-	add	tmp, \data, #(((\windex - 3) & 15) * 16)
-	ld1	{vT3.4s}, [tmp]
-	add	tmp, \data, #((\windex & 15) * 16)
-	ld1	{vT0.4s}, [tmp]
-	eor	vT1.16b, vT1.16b, vT2.16b
-	eor	vT0.16b, vT0.16b, vT3.16b
-	eor	vT0.16b, vT0.16b, vT1.16b
-	// e = (a leftrotate 5) + f + e + k + w[i]
-	ushr	\reg_t\().4s, vT0.4s, 32 - 1
-	add	\reg_e\().4s, \reg_e\().4s, \reg_k\().4s
-	ushr	vT1.4s, \reg_a\().4s, 32 - 5
-	sli	\reg_t\().4s, vT0.4s, 1
-	add	\reg_e\().4s, \reg_e\().4s, \reg_t\().4s
-	sli	vT1.4s, \reg_a\().4s, 5
-	st1	{\reg_t\().4s}, [tmp]
-	add	\reg_e\().4s, \reg_e\().4s, vT1.4s
-	mov	\reg_t\().16b, \reg_b\().16b
-	\func_f	\reg_f\(), \reg_b\(), \reg_c\(), \reg_d\()
-	ushr	\reg_b\().4s, \reg_t\().4s, 32 - 30
-	add	\reg_e\().4s, \reg_e\().4s, \reg_f\().4s
-	sli	\reg_b\().4s, \reg_t\().4s, 30
-.endm
-
-declare_var_vector_reg	VA, 0
-declare_var_vector_reg	VB, 1
-declare_var_vector_reg	VC, 2
-declare_var_vector_reg	VD, 3
-declare_var_vector_reg	VE, 4
-declare_var_vector_reg	VF, 5
-declare_var_vector_reg	vKey, 6
-declare_var_vector_reg	vTmp, 7
-declare_var_vector_reg	vT0, 16
-declare_var_vector_reg	vT1, 17
-declare_var_vector_reg	vT2, 18
-declare_var_vector_reg	vT3, 19
-declare_var_vector_reg	vAA, 20
-declare_var_vector_reg	vBB, 21
-declare_var_vector_reg	vCC, 22
-declare_var_vector_reg	vDD, 23
-declare_var_vector_reg	vEE, 24
-declare_var_vector_reg	TT, 0
-
-.macro SWAP_STATES
-	.unreq TT
-	TT .req VE
-	.unreq VE
-	VE .req VD
-	.unreq VD
-	VD .req VC
-	.unreq VC
-	VC .req VB
-	.unreq VB
-	VB .req VA
-	.unreq VA
-	VA .req TT
+.macro load_x4_word idx:req
+	ld1 {WORD\idx\().16b},[segs_ptr]
+	add segs_ptr,segs_ptr,#64
 .endm
 
 /*
@@ -154,134 +51,51 @@ declare_var_vector_reg	TT, 0
 	sha1_digest	.req	x1
 	data_buf	.req	x2
 	num_blocks	.req	w3
-
-	src	.req	x5
-	dst	.req	x6
-	offs	.req	x7
-	mh_segs	.req	x8
-	key	.req	w9
-	key_adr	.req	x9
-	tmp	.req	x10
+	src	.req	x4
+	dst	.req	x5
+	offs	.req	x6
+	mh_segs	.req	x7
+	tmp	.req	x8
+	segs_ptr	.req	x9
+	block_ctr	.req	w10
 
 	.global mh_sha1_block_asimd
 	.type mh_sha1_block_asimd, %function
 mh_sha1_block_asimd:
 	cmp	num_blocks, #0
 	beq	.return
-
-.block_loop:
-	mov	src, input_data
-.set counter, 0
-
-.rept 16
-	// reverse the input data to big-endian
-	// and transform input data from DWORD*16_SEGS to DWORD*4_SEGS * 4
-	// so that we are able to process 4 SEGS each time by 128-bit NEON
-	ld1	{vT0.4S, vT1.4S, vT2.4S, vT3.4S}, [src], #64
-
-	rev32	vT0.16b, vT0.16b
-	add	dst, data_buf, counter * 16
-	rev32	vT1.16b, vT1.16b
-	st1	{vT0.4S}, [dst]
-	add	dst, dst, 256
-	rev32	vT2.16b, vT2.16b
-	st1	{vT1.4S}, [dst]
-	add	dst, dst, 256
-	rev32	vT3.16b, vT3.16b
-	st1	{vT2.4S}, [dst]
-	add	dst, dst, 256
-	st1	{vT3.4S}, [dst]
-
-	.set counter, counter+1
-.endr
+	sha1_asimd_save_stack
 
 	mov	mh_segs, #0
-
 .seg_loops:
+	add	segs_ptr,input_data,mh_segs
 	mov	offs, #64
-	/* load four segments of digest each time */
 	add	src, sha1_digest, mh_segs
 	ld1	{VA.4S}, [src], offs
 	ld1	{VB.4S}, [src], offs
-	mov	vAA.16B, VA.16B
 	ld1	{VC.4S}, [src], offs
-	mov	vBB.16B, VB.16B
 	ld1	{VD.4S}, [src], offs
-	mov	vCC.16B, VC.16B
 	ld1	{VE.4S}, [src], offs
-	mov	vDD.16B, VD.16B
-	mov	vEE.16B, VE.16B
+	mov	block_ctr,num_blocks
 
-	.set WI, 0
+.block_loop:
+	sha1_single
+	subs	block_ctr, block_ctr, 1
+	bne	.block_loop
 
-	adr	key_adr, KEY_0
-	ld1	{vKey.4s}, [key_adr]
-
-	// 0 ~ 15
-.rept 16
-	SHA1_STEP_00_15	VA,VB,VC,VD,VE,VF,WI,vKey,data_buf,FUNC_F0,vTmp
-	SWAP_STATES
-	.set WI, WI + 1
-.endr
-
-	// 16 ~ 19
-.rept 4
-	SHA1_STEP_16_79	VA,VB,VC,VD,VE,VF,WI,vKey,data_buf,FUNC_F0,vTmp
-	SWAP_STATES
-	.set WI, WI + 1
-.endr
-
-	// 20 ~ 39
-	adr	key_adr, KEY_1
-	ld1	{vKey.4s}, [key_adr]
-.rept 20
-	SHA1_STEP_16_79	VA,VB,VC,VD,VE,VF,WI,vKey,data_buf,FUNC_F1,vTmp
-
-	SWAP_STATES
-	.set WI, WI + 1
-.endr
-
-	// 40 ~ 59
-	adr	key_adr, KEY_2
-	ld1	{vKey.4s}, [key_adr]
-.rept 20
-	SHA1_STEP_16_79	VA,VB,VC,VD,VE,VF,WI,vKey,data_buf,FUNC_F2,vTmp
-	SWAP_STATES
-	.set WI, WI + 1
-.endr
-
-	// 60 ~ 79
-	adr	key_adr, KEY_3
-	ld1	{vKey.4s}, [key_adr]
-.rept 20
-	SHA1_STEP_16_79	VA,VB,VC,VD,VE,VF,WI,vKey,data_buf,FUNC_F3,vTmp
-	SWAP_STATES
-	.set WI, WI + 1
-.endr
-
-	add	VA.4s, vAA.4s, VA.4s
 	mov	offs, #64
 	add	dst, sha1_digest, mh_segs
-	add	VB.4s, vBB.4s, VB.4s
 	st1	{VA.4S}, [dst], offs
-	add	VC.4s, vCC.4s, VC.4s
 	st1	{VB.4S}, [dst], offs
-	add	VD.4s, vDD.4s, VD.4s
 	st1	{VC.4S}, [dst], offs
-	add	VE.4s, vEE.4s, VE.4s
 	st1	{VD.4S}, [dst], offs
 	st1	{VE.4S}, [dst], offs
 
-	add	data_buf, data_buf, 256
 	add	mh_segs, mh_segs, #16
 	cmp	mh_segs, #64
 	bne	.seg_loops
 
-	sub	data_buf, data_buf, 1024
-	add	input_data, input_data, 1024
-	subs	num_blocks, num_blocks, 1
-	bne	.block_loop
-
+	sha1_asimd_restore_stack
 .return:
 	ret
 

--- a/mh_sha1/aarch64/sha1_asimd_common.S
+++ b/mh_sha1/aarch64/sha1_asimd_common.S
@@ -1,0 +1,269 @@
+/**********************************************************************
+  Copyright(c) 2021 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+	.arch armv8-a
+
+// macro F = (D ^ (B & (C ^ D)))
+.macro FUNC_F0
+	eor	VF.16b, VC.16b, VD.16b
+	and	VF.16b, VB.16b, VF.16b
+	eor	VF.16b, VD.16b, VF.16b
+.endm
+
+// F = (B ^ C ^ D)
+.macro FUNC_F1
+	eor	VF.16b, VB.16b, VC.16b
+	eor	VF.16b, VF.16b, VD.16b
+.endm
+
+// F = ((B & C) | (B & D) | (C & D))
+.macro FUNC_F2
+	and	vT0.16b, VB.16b, VC.16b
+	and	vT1.16b, VB.16b, VD.16b
+	and	vT2.16b, VC.16b, VD.16b
+	orr	VF.16b, vT0.16b, vT1.16b
+	orr	VF.16b, VF.16b, vT2.16b
+.endm
+
+// F = (B ^ C ^ D)
+.macro FUNC_F3
+	FUNC_F1
+.endm
+
+.altmacro
+.macro load_next_word windex
+	.if \windex < 16
+		load_x4_word	\windex
+	.endif
+.endm
+
+// FUNC_F0 is merged into STEP_00_15 for efficiency
+.macro SHA1_STEP_00_15_F0 windex:req
+	rev32	WORD\windex\().16b,WORD\windex\().16b
+	next_word=\windex+1
+	load_next_word %next_word
+	// e = (a leftrotate 5) + f + e + k + w[i]
+	ushr	VT.4s, VA.4s, 32 - 5
+	add	VE.4s, VE.4s, VK.4s
+	sli	VT.4s, VA.4s, 5
+	eor	VF.16b, VC.16b, VD.16b
+	add	VE.4s, VE.4s, WORD\windex\().4s
+	and	VF.16b, VB.16b, VF.16b
+	add	VE.4s, VE.4s, VT.4s
+	eor	VF.16b, VD.16b, VF.16b
+	ushr	VT.4s, VB.4s, 32 - 30
+	add	VE.4s, VE.4s, VF.4s
+	sli	VT.4s, VB.4s, 30
+.endm
+
+.macro SHA1_STEP_16_79 windex:req,func_f:req,reg_3:req,reg_8:req,reg_14:req,reg_16:req
+	eor	vT0.16b,\reg_3\().16b,\reg_8\().16b
+	eor	VT.16b,\reg_14\().16b,\reg_16\().16b
+	eor	vT0.16b,vT0.16b,VT.16b
+	// e = (a leftrotate 5) + f + e + k + w[i]
+	ushr	VT.4s, vT0.4s, 32 - 1
+	add	VE.4s, VE.4s, VK.4s
+	ushr	vT1.4s, VA.4s, 32 - 5
+	sli	VT.4s, vT0.4s, 1
+	add	VE.4s, VE.4s, VT.4s
+	sli	vT1.4s, VA.4s, 5
+	mov	\reg_16\().16b,VT.16b
+	add	VE.4s, VE.4s, vT1.4s
+	ushr	VT.4s, VB.4s, 32 - 30
+	\func_f
+	add	VE.4s, VE.4s, VF.4s
+	sli	VT.4s, VB.4s, 30
+.endm
+
+	VA	.req v0
+	VB	.req v1
+	VC	.req v2
+	VD	.req v3
+	VE	.req v4
+	VT	.req v5
+	VF	.req v6
+	VK	.req v7
+	WORD0	.req v8
+	WORD1	.req v9
+	WORD2	.req v10
+	WORD3	.req v11
+	WORD4	.req v12
+	WORD5	.req v13
+	WORD6	.req v14
+	WORD7	.req v15
+	WORD8	.req v16
+	WORD9	.req v17
+	WORD10	.req v18
+	WORD11	.req v19
+	WORD12	.req v20
+	WORD13	.req v21
+	WORD14	.req v22
+	WORD15	.req v23
+	vT0	.req v24
+	vT1	.req v25
+	vT2	.req v26
+	vAA	.req v27
+	vBB	.req v28
+	vCC	.req v29
+	vDD	.req v30
+	vEE	.req v31
+	TT	.req v0
+	sha1key_adr	.req	x15
+
+.macro SWAP_STATES
+	// shifted VB is held in VT after each step
+	.unreq TT
+	TT .req VE
+	.unreq VE
+	VE .req VD
+	.unreq VD
+	VD .req VC
+	.unreq VC
+	VC .req VT
+	.unreq	VT
+	VT .req VB
+	.unreq VB
+	VB .req VA
+	.unreq VA
+	VA .req TT
+.endm
+
+.altmacro
+.macro SHA1_STEP_16_79_WRAPPER windex:req,func_f:req,idx3:req,idx8:req,idx14:req,idx16:req
+	SHA1_STEP_16_79 \windex,\func_f,WORD\idx3\(),WORD\idx8\(),WORD\idx14\(),WORD\idx16\()
+.endm
+
+.macro exec_step windex:req
+	.if \windex <= 15
+		SHA1_STEP_00_15_F0	windex
+	.else
+		idx14=((\windex - 14) & 15)
+		idx8=((\windex - 8) & 15)
+		idx3=((\windex - 3) & 15)
+		idx16=(\windex & 15)
+		.if \windex <= 19
+			SHA1_STEP_16_79_WRAPPER	\windex,FUNC_F0,%idx3,%idx8,%idx14,%idx16
+		.endif
+		.if \windex >= 20 && \windex <= 39
+			SHA1_STEP_16_79_WRAPPER	\windex,FUNC_F1,%idx3,%idx8,%idx14,%idx16
+		.endif
+		.if \windex >= 40 && \windex <= 59
+			SHA1_STEP_16_79_WRAPPER	\windex,FUNC_F2,%idx3,%idx8,%idx14,%idx16
+		.endif
+		.if \windex >= 60 && \windex <= 79
+			SHA1_STEP_16_79_WRAPPER	\windex,FUNC_F3,%idx3,%idx8,%idx14,%idx16
+		.endif
+	.endif
+
+	SWAP_STATES
+
+	.if \windex == 79
+		// after 80 steps, the registers ABCDET has shifted from
+		// its orignal order of 012345 to 341520
+		// have to swap back for both compile- and run-time correctness
+		mov	v0.16b,v3.16b
+		.unreq VA
+		VA	.req v0
+
+		mov	vT0.16b,v2.16b
+		mov	v2.16b,v1.16b
+		mov	v1.16b,v4.16b
+		.unreq VB
+		VB	.req v1
+		.unreq VC
+		VC	.req v2
+
+		mov	v3.16b,v5.16b
+		.unreq VD
+		VD	.req v3
+
+		mov	v4.16b,vT0.16b
+		.unreq VE
+		VE	.req v4
+
+		.unreq VT
+		VT	.req v5
+	.endif
+.endm
+
+.macro exec_steps idx:req,more:vararg
+	exec_step	\idx
+	.ifnb \more
+		exec_steps	\more
+	.endif
+.endm
+
+.macro sha1_single
+	load_x4_word 0
+
+	mov	vAA.16B, VA.16B
+	mov	vBB.16B, VB.16B
+	mov	vCC.16B, VC.16B
+	mov	vDD.16B, VD.16B
+	mov	vEE.16B, VE.16B
+
+	adr	sha1key_adr, KEY_0
+	ld1	{VK.4s}, [sha1key_adr]
+	exec_steps	0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19
+
+	// 20 ~ 39
+	adr	sha1key_adr, KEY_1
+	ld1	{VK.4s}, [sha1key_adr]
+	exec_steps	20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39
+
+	// 40 ~ 59
+	adr	sha1key_adr, KEY_2
+	ld1	{VK.4s}, [sha1key_adr]
+	exec_steps	40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59
+
+	// 60 ~ 79
+	adr	sha1key_adr, KEY_3
+	ld1	{VK.4s}, [sha1key_adr]
+	exec_steps	60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79
+
+	add	VA.4s, vAA.4s, VA.4s
+	add	VB.4s, vBB.4s, VB.4s
+	add	VC.4s, vCC.4s, VC.4s
+	add	VD.4s, vDD.4s, VD.4s
+	add	VE.4s, vEE.4s, VE.4s
+.endm
+
+.macro sha1_asimd_save_stack
+	stp	d8,d9,[sp, -64]!
+	stp	d10,d11,[sp, 16]
+	stp	d12,d13,[sp, 32]
+	stp	d14,d15,[sp, 48]
+.endm
+
+.macro sha1_asimd_restore_stack
+	ldp	d10,d11,[sp, 16]
+	ldp	d12,d13,[sp, 32]
+	ldp	d14,d15,[sp, 48]
+	ldp	d8,d9,[sp],64
+.endm

--- a/mh_sha1_murmur3_x64_128/Makefile.am
+++ b/mh_sha1_murmur3_x64_128/Makefile.am
@@ -52,6 +52,8 @@ lsrc_aarch64 += $(lsrc_murmur)	\
 		mh_sha1_murmur3_x64_128/aarch64/mh_sha1_murmur3_aarch64_dispatcher.c \
 		mh_sha1_murmur3_x64_128/aarch64/mh_sha1_murmur3_ce.c \
 		mh_sha1_murmur3_x64_128/aarch64/mh_sha1_murmur3_block_ce.S \
+		mh_sha1_murmur3_x64_128/aarch64/mh_sha1_murmur3_asimd.c \
+		mh_sha1_murmur3_x64_128/aarch64/mh_sha1_murmur3_block_asimd.S \
 		mh_sha1_murmur3_x64_128/aarch64/mh_sha1_murmur3_multibinary.S
 
 lsrc_base_aliases += $(lsrc_murmur)	\

--- a/mh_sha1_murmur3_x64_128/aarch64/mh_sha1_murmur3_aarch64_internal.h
+++ b/mh_sha1_murmur3_x64_128/aarch64/mh_sha1_murmur3_aarch64_internal.h
@@ -64,6 +64,27 @@ void mh_sha1_murmur3_block_ce(const uint8_t * input_data,
 				      murmur3_x64_128_digests[MURMUR3_x64_128_DIGEST_WORDS],
 				      uint32_t num_blocks);
 
+ /**
+  * @brief  Calculate blocks which size is MH_SHA1_BLOCK_SIZE*N
+  *
+  * @requires ASIMD
+  *
+  * @param  input_data Pointer to input data to be processed
+  * @param  mh_sha1_digests 16 segments digests
+  * @param  frame_buffer Pointer to buffer which is a temp working area
+  * @param  murmur3_x64_128_digests Murmur3 digest
+  * @param  num_blocks The number of blocks.
+  * @returns none
+  *
+  */
+void mh_sha1_murmur3_block_asimd(const uint8_t * input_data,
+				      uint32_t mh_sha1_digests[SHA1_DIGEST_WORDS][HASH_SEGS],
+				      uint8_t frame_buffer[MH_SHA1_BLOCK_SIZE],
+				      uint32_t
+				      murmur3_x64_128_digests[MURMUR3_x64_128_DIGEST_WORDS],
+				      uint32_t num_blocks);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/mh_sha1_murmur3_x64_128/aarch64/mh_sha1_murmur3_block_asimd.S
+++ b/mh_sha1_murmur3_x64_128/aarch64/mh_sha1_murmur3_block_asimd.S
@@ -1,0 +1,224 @@
+/**********************************************************************
+  Copyright(c) 2021 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+	.arch armv8-a
+
+#include "sha1_asimd_common.S"
+.macro sha1_step_16_79_interleave0 windex:req
+	// interleaving murmur3 operation
+	.if (\windex % 4) == 0
+		ldp mur_data1, mur_data2, [mur_data], #16
+	.endif
+	.if (\windex % 4) == 1
+		/* rotate left by 31 bits */
+		ror	mur_data1, mur_data1, #64-31
+		/* rotate left by 33 bits */
+		ror	mur_data2, mur_data2, #64-33
+	.endif
+	.if (\windex % 4) == 2
+		eor	mur_hash1, mur_hash1, mur_data1
+		/* rotate left by 27 bits */
+		ror	mur_hash1, mur_hash1, #64-27
+	.endif
+	.if (\windex % 4) == 3
+		eor	mur_hash2, mur_hash2, mur_data2
+		/* rotate left by 31 bits */
+		ror	mur_hash2, mur_hash2, #64-31
+	.endif
+.endm
+
+.macro sha1_step_16_79_interleave1 windex:req
+	// interleaving murmur3 operation
+	.if (\windex % 4) == 0
+		mul	mur_data1, mur_data1, mur_c1
+		mul	mur_data2, mur_data2, mur_c2
+	.endif
+	.if (\windex % 4) == 1
+		mul	mur_data1, mur_data1, mur_c2
+		mul	mur_data2, mur_data2, mur_c1
+	.endif
+	.if (\windex % 4) == 2
+		add	mur_hash1, mur_hash1, mur_hash2
+		//mur_hash1 = mur_hash1 * 5 + N1
+		add	mur_hash1, mur_hash1, mur_hash1, LSL #2
+		add	mur_hash1, mur_n1, mur_hash1
+	.endif
+	.if (\windex % 4) == 3
+		add	mur_hash2, mur_hash2, mur_hash1
+		// mur_hash2 = mur_hash2 * 5 + N2
+		add	mur_hash2, mur_hash2, mur_hash2, LSL #2
+		add	mur_hash2, mur_n2, mur_hash2
+	.endif
+.endm
+
+.macro load_x4_word idx:req
+	ld1 {WORD\idx\().16b},[segs_ptr]
+	add segs_ptr,segs_ptr,#64
+.endm
+
+/*
+ * void mh_sha1_murmur3_block_asimd (const uint8_t * input_data,
+ *                               uint32_t mh_sha1_digests[SHA1_DIGEST_WORDS][HASH_SEGS],
+ *                               uint8_t frame_buffer[MH_SHA1_BLOCK_SIZE],
+ *                               uint32_t murmur3_x64_128_digests[MURMUR3_x64_128_DIGEST_WORDS],
+ *                               uint32_t num_blocks);
+ * arg 0 pointer to input data
+ * arg 1 pointer to digests, include segments digests(uint32_t digests[16][5])
+ * arg 2 pointer to aligned_frame_buffer which is used to save the big_endian data.
+ * arg 3 pointer to murmur3 digest
+ * arg 4 number  of 1KB blocks
+ */
+
+	input_data	.req	x0
+	sha1_digest	.req	x1
+	data_buf	.req	x2
+	mur_digest	.req	x3
+	num_blocks	.req	w4
+
+	src	.req	x5
+	dst	.req	x6
+	offs	.req	x7
+	mh_segs	.req	x8
+	tmp	.req	x9
+	tmpw	.req	w9
+	segs_ptr	.req	x10
+	mur_hash1	.req	x11
+	mur_hash2	.req	x12
+	mur_c1	.req	x13
+	mur_c2	.req	x14
+	mur_data1	.req	x19
+	mur_data2	.req	x20
+	mur_data	.req	x21
+	mur_n1		.req	x22
+	mur_n1_w	.req	w22
+	mur_n2		.req	x23
+	mur_n2_w	.req	w23
+	block_ctr	.req	w24
+
+	.global mh_sha1_murmur3_block_asimd
+	.type mh_sha1_murmur3_block_asimd, %function
+mh_sha1_murmur3_block_asimd:
+	cmp	num_blocks, #0
+	beq	.return
+	sha1_asimd_save_stack
+	stp	x19, x20, [sp, -48]!
+	stp	x21, x22, [sp, 16]
+	stp	x23, x24, [sp, 32]
+
+	mov	mur_data, input_data
+	ldr	mur_hash1, [mur_digest]
+	ldr	mur_hash2, [mur_digest, 8]
+	adr	mur_c1, C1
+	ldr	mur_c1, [mur_c1]
+	adr	mur_c2, C2
+	ldr	mur_c2, [mur_c2]
+	adr	tmp, N1
+	ldr	mur_n1_w, [tmp]
+	adr	tmp, N2
+	ldr	mur_n2_w, [tmp]
+
+	mov	mh_segs, #0
+.seg_loops:
+	add	segs_ptr,input_data,mh_segs
+	mov	offs, #64
+	add	src, sha1_digest, mh_segs
+	ld1	{VA.4S}, [src], offs
+	ld1	{VB.4S}, [src], offs
+	ld1	{VC.4S}, [src], offs
+	ld1	{VD.4S}, [src], offs
+	ld1	{VE.4S}, [src], offs
+	mov	block_ctr,num_blocks
+
+.block_loop:
+	sha1_single
+	subs	block_ctr, block_ctr, 1
+	bne	.block_loop
+
+	mov	offs, #64
+	add	dst, sha1_digest, mh_segs
+	st1	{VA.4S}, [dst], offs
+	st1	{VB.4S}, [dst], offs
+	st1	{VC.4S}, [dst], offs
+	st1	{VD.4S}, [dst], offs
+	st1	{VE.4S}, [dst], offs
+
+	add	mh_segs, mh_segs, #16
+	cmp	mh_segs, #64
+	bne	.seg_loops
+
+	/* save murmur-hash digest */
+	str	mur_hash1, [mur_digest], #8
+	str	mur_hash2, [mur_digest]
+
+	ldp	x21, x22, [sp, 16]
+	ldp	x23, x24, [sp, 32]
+	ldp	x19, x20, [sp], 48
+	sha1_asimd_restore_stack
+.return:
+	ret
+
+	.size mh_sha1_murmur3_block_asimd, .-mh_sha1_murmur3_block_asimd
+	.section .rodata.cst16,"aM",@progbits,16
+	.align  16
+KEY_0:
+	.word	0x5a827999
+	.word	0x5a827999
+	.word	0x5a827999
+	.word	0x5a827999
+KEY_1:
+	.word	0x6ed9eba1
+	.word	0x6ed9eba1
+	.word	0x6ed9eba1
+	.word	0x6ed9eba1
+KEY_2:
+	.word	0x8f1bbcdc
+	.word	0x8f1bbcdc
+	.word	0x8f1bbcdc
+	.word	0x8f1bbcdc
+KEY_3:
+	.word	0xca62c1d6
+	.word	0xca62c1d6
+	.word	0xca62c1d6
+	.word	0xca62c1d6
+N1:
+	.word	0x52dce729
+	.word	0x52dce729
+	.word	0x52dce729
+	.word	0x52dce729
+N2:
+	.word	0x38495ab5
+	.word	0x38495ab5
+	.word	0x38495ab5
+	.word	0x38495ab5
+C1:
+	.dword	0x87c37b91114253d5
+	.dword	0x87c37b91114253d5
+C2:
+	.dword	0x4cf5ad432745937f
+	.dword	0x4cf5ad432745937f

--- a/mh_sha1_murmur3_x64_128/aarch64/sha1_asimd_common.S
+++ b/mh_sha1_murmur3_x64_128/aarch64/sha1_asimd_common.S
@@ -1,0 +1,271 @@
+/**********************************************************************
+  Copyright(c) 2021 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+	.arch armv8-a
+
+// macro F = (D ^ (B & (C ^ D)))
+.macro FUNC_F0
+	eor	VF.16b, VC.16b, VD.16b
+	and	VF.16b, VB.16b, VF.16b
+	eor	VF.16b, VD.16b, VF.16b
+.endm
+
+// F = (B ^ C ^ D)
+.macro FUNC_F1
+	eor	VF.16b, VB.16b, VC.16b
+	eor	VF.16b, VF.16b, VD.16b
+.endm
+
+// F = ((B & C) | (B & D) | (C & D))
+.macro FUNC_F2
+	and	vT0.16b, VB.16b, VC.16b
+	and	vT1.16b, VB.16b, VD.16b
+	and	vT2.16b, VC.16b, VD.16b
+	orr	VF.16b, vT0.16b, vT1.16b
+	orr	VF.16b, VF.16b, vT2.16b
+.endm
+
+// F = (B ^ C ^ D)
+.macro FUNC_F3
+	FUNC_F1
+.endm
+
+.altmacro
+.macro load_next_word windex
+	.if \windex < 16
+		load_x4_word	\windex
+	.endif
+.endm
+
+// FUNC_F0 is merged into STEP_00_15 for efficiency
+.macro SHA1_STEP_00_15_F0 windex:req
+	rev32	WORD\windex\().16b,WORD\windex\().16b
+	next_word=\windex+1
+	load_next_word %next_word
+	// e = (a leftrotate 5) + f + e + k + w[i]
+	ushr	VT.4s, VA.4s, 32 - 5
+	add	VE.4s, VE.4s, VK.4s
+	sli	VT.4s, VA.4s, 5
+	eor	VF.16b, VC.16b, VD.16b
+	add	VE.4s, VE.4s, WORD\windex\().4s
+	and	VF.16b, VB.16b, VF.16b
+	add	VE.4s, VE.4s, VT.4s
+	eor	VF.16b, VD.16b, VF.16b
+	ushr	VT.4s, VB.4s, 32 - 30
+	add	VE.4s, VE.4s, VF.4s
+	sli	VT.4s, VB.4s, 30
+.endm
+
+.macro SHA1_STEP_16_79 windex:req,func_f:req,reg_3:req,reg_8:req,reg_14:req,reg_16:req
+	eor	vT0.16b,\reg_3\().16b,\reg_8\().16b
+	eor	VT.16b,\reg_14\().16b,\reg_16\().16b
+	sha1_step_16_79_interleave0	\windex
+	eor	vT0.16b,vT0.16b,VT.16b
+	sha1_step_16_79_interleave1	\windex
+	// e = (a leftrotate 5) + f + e + k + w[i]
+	ushr	VT.4s, vT0.4s, 32 - 1
+	add	VE.4s, VE.4s, VK.4s
+	ushr	vT1.4s, VA.4s, 32 - 5
+	sli	VT.4s, vT0.4s, 1
+	add	VE.4s, VE.4s, VT.4s
+	sli	vT1.4s, VA.4s, 5
+	mov	\reg_16\().16b,VT.16b
+	add	VE.4s, VE.4s, vT1.4s
+	ushr	VT.4s, VB.4s, 32 - 30
+	\func_f
+	add	VE.4s, VE.4s, VF.4s
+	sli	VT.4s, VB.4s, 30
+.endm
+
+	VA	.req v0
+	VB	.req v1
+	VC	.req v2
+	VD	.req v3
+	VE	.req v4
+	VT	.req v5
+	VF	.req v6
+	VK	.req v7
+	WORD0	.req v8
+	WORD1	.req v9
+	WORD2	.req v10
+	WORD3	.req v11
+	WORD4	.req v12
+	WORD5	.req v13
+	WORD6	.req v14
+	WORD7	.req v15
+	WORD8	.req v16
+	WORD9	.req v17
+	WORD10	.req v18
+	WORD11	.req v19
+	WORD12	.req v20
+	WORD13	.req v21
+	WORD14	.req v22
+	WORD15	.req v23
+	vT0	.req v24
+	vT1	.req v25
+	vT2	.req v26
+	vAA	.req v27
+	vBB	.req v28
+	vCC	.req v29
+	vDD	.req v30
+	vEE	.req v31
+	TT	.req v0
+	sha1key_adr	.req	x15
+
+.macro SWAP_STATES
+	// shifted VB is held in VT after each step
+	.unreq TT
+	TT .req VE
+	.unreq VE
+	VE .req VD
+	.unreq VD
+	VD .req VC
+	.unreq VC
+	VC .req VT
+	.unreq	VT
+	VT .req VB
+	.unreq VB
+	VB .req VA
+	.unreq VA
+	VA .req TT
+.endm
+
+.altmacro
+.macro SHA1_STEP_16_79_WRAPPER windex:req,func_f:req,idx3:req,idx8:req,idx14:req,idx16:req
+	SHA1_STEP_16_79 \windex,\func_f,WORD\idx3\(),WORD\idx8\(),WORD\idx14\(),WORD\idx16\()
+.endm
+
+.macro exec_step windex:req
+	.if \windex <= 15
+		SHA1_STEP_00_15_F0	windex
+	.else
+		idx14=((\windex - 14) & 15)
+		idx8=((\windex - 8) & 15)
+		idx3=((\windex - 3) & 15)
+		idx16=(\windex & 15)
+		.if \windex <= 19
+			SHA1_STEP_16_79_WRAPPER	\windex,FUNC_F0,%idx3,%idx8,%idx14,%idx16
+		.endif
+		.if \windex >= 20 && \windex <= 39
+			SHA1_STEP_16_79_WRAPPER	\windex,FUNC_F1,%idx3,%idx8,%idx14,%idx16
+		.endif
+		.if \windex >= 40 && \windex <= 59
+			SHA1_STEP_16_79_WRAPPER	\windex,FUNC_F2,%idx3,%idx8,%idx14,%idx16
+		.endif
+		.if \windex >= 60 && \windex <= 79
+			SHA1_STEP_16_79_WRAPPER	\windex,FUNC_F3,%idx3,%idx8,%idx14,%idx16
+		.endif
+	.endif
+
+	SWAP_STATES
+
+	.if \windex == 79
+		// after 80 steps, the registers ABCDET has shifted from
+		// its orignal order of 012345 to 341520
+		// have to swap back for both compile- and run-time correctness
+		mov	v0.16b,v3.16b
+		.unreq VA
+		VA	.req v0
+
+		mov	vT0.16b,v2.16b
+		mov	v2.16b,v1.16b
+		mov	v1.16b,v4.16b
+		.unreq VB
+		VB	.req v1
+		.unreq VC
+		VC	.req v2
+
+		mov	v3.16b,v5.16b
+		.unreq VD
+		VD	.req v3
+
+		mov	v4.16b,vT0.16b
+		.unreq VE
+		VE	.req v4
+
+		.unreq VT
+		VT	.req v5
+	.endif
+.endm
+
+.macro exec_steps idx:req,more:vararg
+	exec_step	\idx
+	.ifnb \more
+		exec_steps	\more
+	.endif
+.endm
+
+.macro sha1_single
+	load_x4_word 0
+
+	mov	vAA.16B, VA.16B
+	mov	vBB.16B, VB.16B
+	mov	vCC.16B, VC.16B
+	mov	vDD.16B, VD.16B
+	mov	vEE.16B, VE.16B
+
+	adr	sha1key_adr, KEY_0
+	ld1	{VK.4s}, [sha1key_adr]
+	exec_steps	0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19
+
+	// 20 ~ 39
+	adr	sha1key_adr, KEY_1
+	ld1	{VK.4s}, [sha1key_adr]
+	exec_steps	20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39
+
+	// 40 ~ 59
+	adr	sha1key_adr, KEY_2
+	ld1	{VK.4s}, [sha1key_adr]
+	exec_steps	40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59
+
+	// 60 ~ 79
+	adr	sha1key_adr, KEY_3
+	ld1	{VK.4s}, [sha1key_adr]
+	exec_steps	60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79
+
+	add	VA.4s, vAA.4s, VA.4s
+	add	VB.4s, vBB.4s, VB.4s
+	add	VC.4s, vCC.4s, VC.4s
+	add	VD.4s, vDD.4s, VD.4s
+	add	VE.4s, vEE.4s, VE.4s
+.endm
+
+.macro sha1_asimd_save_stack
+	stp	d8,d9,[sp, -64]!
+	stp	d10,d11,[sp, 16]
+	stp	d12,d13,[sp, 32]
+	stp	d14,d15,[sp, 48]
+.endm
+
+.macro sha1_asimd_restore_stack
+	ldp	d10,d11,[sp, 16]
+	ldp	d12,d13,[sp, 32]
+	ldp	d14,d15,[sp, 48]
+	ldp	d8,d9,[sp],64
+.endm


### PR DESCRIPTION
This patches implements mh-sha1-murmur3 for aarch64 by cpu feature ASIMD.
When SHA1 crypto extension is not avaiable, ASIMD can provide a
performance uplift around 50%~120% for many micro-architectures over
base non-optimized implementation

Change-Id: Ib9f1654d3e5233475fc7d27973eb29df31b40346
Signed-off-by: Daniel Hu <Daniel.Hu@arm.com>