### PR TITLE
Always check the result of posix_memalign() calls

### DIFF
--- a/aes/cbc_ossl_perf.c
+++ b/aes/cbc_ossl_perf.c
@@ -79,12 +79,12 @@ int aes_128_perf(uint8_t * key)
 	ret = posix_memalign((void **)&iv, 16, (CBC_IV_DATA_LEN));
 	if (ret) {
 		printf("alloc error: Fail");
-		return -1;
+		return 1;
 	}
 	ret = posix_memalign((void **)&key_data, 16, (sizeof(*key_data)));
 	if (ret) {
 		printf("alloc error: Fail");
-		return -1;
+		return 1;
 	}
 	if ((NULL == iv) || (NULL == key_data))
 		return 1;
@@ -160,12 +160,12 @@ int aes_192_perf(uint8_t * key)
 	ret = posix_memalign((void **)&iv, 16, (CBC_IV_DATA_LEN));
 	if (ret) {
 		printf("alloc error: Fail");
-		return -1;
+		return 1;
 	}
 	ret = posix_memalign((void **)&key_data, 16, (sizeof(*key_data)));
 	if (ret) {
 		printf("alloc error: Fail");
-		return -1;
+		return 1;
 	}
 	if ((NULL == iv) || (NULL == key_data))
 		return 1;
@@ -240,12 +240,12 @@ int aes_256_perf(uint8_t * key)
 	ret = posix_memalign((void **)&iv, 16, (CBC_IV_DATA_LEN));
 	if (ret) {
 		printf("alloc error: Fail");
-		return -1;
+		return 1;
 	}
 	ret = posix_memalign((void **)&key_data, 16, (sizeof(*key_data)));
 	if (ret) {
 		printf("alloc error: Fail");
-		return -1;
+		return 1;
 	}
 	if ((NULL == iv) || (NULL == key_data))
 		return 1;

--- a/aes/cbc_std_vectors_random_test.c
+++ b/aes/cbc_std_vectors_random_test.c
@@ -245,22 +245,22 @@ int check_vector(struct cbc_vector *vector)
 int test_std_combinations(void)
 {
 	int const vectors_cnt = sizeof(cbc_vectors) / sizeof(cbc_vectors[0]);
-	int i;
+	int i, ret;
 	uint8_t *iv = NULL;
 
 	printf("AES CBC standard test vectors:");
 #ifdef CBC_VECTORS_VERBOSE
 	printf("\n");
 #endif
-	posix_memalign((void **)&iv, 16, (CBC_IV_DATA_LEN));
-	if (NULL == iv)
+	ret = posix_memalign((void **)&iv, 16, (CBC_IV_DATA_LEN));
+	if ((0 != ret) || (NULL == iv))
 		return 1;
 
 	for (i = 0; (i < vectors_cnt); i++) {
 		struct cbc_vector vect = cbc_vectors[i];
 
-		posix_memalign((void **)&vect.KEYS, 16, (sizeof(*vect.KEYS)));
-		if (NULL == vect.KEYS)
+		ret = posix_memalign((void **)&vect.KEYS, 16, (sizeof(*vect.KEYS)));
+		if ((0 != ret) || (NULL == vect.KEYS))
 			return 1;
 		// IV data must be aligned to 16 byte boundary so move data in aligned buffer and change out the pointer
 		memcpy(iv, vect.IV, CBC_IV_DATA_LEN);
@@ -292,19 +292,19 @@ int test_std_combinations(void)
 int test_random_combinations(void)
 {
 	struct cbc_vector test;
-	int t;
+	int t, ret;
 
 	printf("AES CBC random test vectors:");
 #ifdef CBC_VECTORS_VERBOSE
 	fflush(0);
 #endif
 	test.IV = NULL;
-	posix_memalign((void **)&test.IV, 16, (CBC_IV_DATA_LEN));
-	if (NULL == test.IV)
+	ret = posix_memalign((void **)&test.IV, 16, (CBC_IV_DATA_LEN));
+	if ((0 != ret) || (NULL == test.IV))
 		return 1;
 	test.KEYS = NULL;
-	posix_memalign((void **)&test.KEYS, 16, (sizeof(*test.KEYS)));
-	if (NULL == test.KEYS)
+	ret = posix_memalign((void **)&test.KEYS, 16, (sizeof(*test.KEYS)));
+	if ((0 != ret) || (NULL == test.KEYS))
 		return 1;
 
 	for (t = 0; RANDOMS > t; t++) {

--- a/aes/cbc_std_vectors_test.c
+++ b/aes/cbc_std_vectors_test.c
@@ -135,20 +135,20 @@ int check_vector(struct cbc_vector *vector)
 int test_std_combinations(void)
 {
 	int const vectors_cnt = sizeof(cbc_vectors) / sizeof(cbc_vectors[0]);
-	int i;
+	int i, ret;
 	uint8_t *iv = NULL;
 
 	printf("AES CBC standard test vectors: ");
 
-	posix_memalign((void **)&iv, 16, (CBC_IV_DATA_LEN));
-	if (NULL == iv)
+	ret = posix_memalign((void **)&iv, 16, (CBC_IV_DATA_LEN));
+	if ((0 != ret) || (NULL == iv))
 		return 1;
 
 	for (i = 0; (i < vectors_cnt); i++) {
 		struct cbc_vector vect = cbc_vectors[i];
 
-		posix_memalign((void **)&(vect.KEYS), 16, sizeof(*vect.KEYS));
-		if (NULL == vect.KEYS)
+		ret = posix_memalign((void **)&(vect.KEYS), 16, sizeof(*vect.KEYS));
+		if ((0 != ret) || (NULL == vect.KEYS))
 			return 1;
 
 		// IV data must be aligned to 16 byte boundary so move data in

--- a/aes/gcm_nt_std_vectors_test.c
+++ b/aes/gcm_nt_std_vectors_test.c
@@ -74,12 +74,13 @@ int test_gcm128_std_vectors_nt(gcm_vector const *vector)
 	uint8_t *T_test = NULL;
 	uint8_t *T2_test = NULL;
 	uint64_t IV_alloc_len = 0;
+	int ret;
 
 	// Allocate space for the calculated ciphertext
-	posix_memalign((void **)&ct_test, 32, vector->Plen);
-	// Allocate space for the calculated ciphertext
-	posix_memalign((void **)&pt_test, 32, vector->Plen);
-	if ((ct_test == NULL) || (pt_test == NULL)) {
+	ret = posix_memalign((void **)&ct_test, 32, vector->Plen);
+	// Allocate space for the calculated plaintext
+	ret |= posix_memalign((void **)&pt_test, 32, vector->Plen);
+	if ((ret != 0) || (ct_test == NULL) || (pt_test == NULL)) {
 		fprintf(stderr, "Can't allocate ciphertext or plaintext memory\n");
 		return 1;
 	}
@@ -177,12 +178,13 @@ int test_gcm256_std_vectors_nt(gcm_vector const *vector)
 	uint8_t *T_test = NULL;
 	uint8_t *T2_test = NULL;
 	uint64_t IV_alloc_len = 0;
+	int ret;
 
 	// Allocate space for the calculated ciphertext
-	posix_memalign((void **)&ct_test, 32, vector->Plen);
-	// Allocate space for the calculated ciphertext
-	posix_memalign((void **)&pt_test, 32, vector->Plen);
-	if ((ct_test == NULL) || (pt_test == NULL)) {
+	ret = posix_memalign((void **)&ct_test, 32, vector->Plen);
+	// Allocate space for the calculated plaintext
+	ret |= posix_memalign((void **)&pt_test, 32, vector->Plen);
+	if ((ret != 0) || (ct_test == NULL) || (pt_test == NULL)) {
 		fprintf(stderr, "Can't allocate ciphertext or plaintext memory\n");
 		return 1;
 	}

--- a/examples/saturation_test/aes_thread.c
+++ b/examples/saturation_test/aes_thread.c
@@ -127,11 +127,12 @@ struct cbc_context {
 static int cbc_dec_pre(struct aes_context *p)
 {
 	struct cbc_context *pCtx = (struct cbc_context *)p;
+	int ret;
 
-	posix_memalign((void **)&pCtx->iv, 16, (CBC_IV_DATA_LEN));
-	posix_memalign((void **)&pCtx->key_data, 16, (sizeof(*pCtx->key_data)));
+	ret = posix_memalign((void **)&pCtx->iv, 16, (CBC_IV_DATA_LEN));
+	ret |= posix_memalign((void **)&pCtx->key_data, 16, (sizeof(*pCtx->key_data)));
 
-	if ((NULL == pCtx->iv) || (NULL == pCtx->key_data))
+	if ((0 != ret) || (NULL == pCtx->iv) || (NULL == pCtx->key_data))
 		return 1;
 
 	mk_rand_data(pCtx->key, sizeof(pCtx->key));

--- a/examples/saturation_test/md5_thread.c
+++ b/examples/saturation_test/md5_thread.c
@@ -118,6 +118,7 @@ void *MB_THREAD_FUNC(void *arg)
 	uint64_t round = -1;
 	struct timeval start_tv, stop_tv;
 	long long secs = run_secs;
+	int ret;
 
 	HASH_CTX_MGR *mgr = NULL;
 	HASH_CTX *ctxpool = NULL, *ctx = NULL;
@@ -151,7 +152,11 @@ void *MB_THREAD_FUNC(void *arg)
 		hash_ctx_init(&ctxpool[i]);
 		ctxpool[i].user_data = (void *)((uint64_t) i);
 	}
-	posix_memalign((void *)&mgr, 16, sizeof(HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		goto out;
+	}
 	CTX_MGR_INIT(mgr);
 
 	printfv("Thread %i gets to wait\n", id);

--- a/md5_mb/md5_mb_rand_ssl_test.c
+++ b/md5_mb/md5_mb_rand_ssl_test.c
@@ -61,12 +61,18 @@ int main(void)
 	uint32_t i, j, fail = 0;
 	uint32_t lens[TEST_BUFS];
 	unsigned int jobs, t;
+	int ret;
 
 	printf("multibinary_md5 test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS, TEST_LEN);
 
 	srand(TEST_SEED);
 
-	posix_memalign((void *)&mgr, 16, sizeof(MD5_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(MD5_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	md5_ctx_mgr_init(mgr);
 
 	for (i = 0; i < TEST_BUFS; i++) {

--- a/md5_mb/md5_mb_rand_test.c
+++ b/md5_mb/md5_mb_rand_test.c
@@ -62,10 +62,16 @@ int main(void)
 	uint32_t lens[TEST_BUFS];
 	unsigned int jobs, t;
 	uint8_t *tmp_buf;
+	int ret;
 
 	printf("multibinary_md5 test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS, TEST_LEN);
 
-	posix_memalign((void *)&mgr, 16, sizeof(MD5_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(MD5_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	md5_ctx_mgr_init(mgr);
 
 	srand(TEST_SEED);

--- a/md5_mb/md5_mb_rand_update_test.c
+++ b/md5_mb/md5_mb_rand_update_test.c
@@ -73,13 +73,19 @@ int main(void)
 	unsigned char *buf_ptr[TEST_BUFS];
 	uint32_t lens[TEST_BUFS];
 	unsigned int joblen, jobs, t;
+	int ret;
 
 	printf("multibinary_md5_update test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS,
 	       TEST_LEN);
 
 	srand(TEST_SEED);
 
-	posix_memalign((void *)&mgr, 16, sizeof(MD5_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(MD5_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	md5_ctx_mgr_init(mgr);
 
 	for (i = 0; i < TEST_BUFS; i++) {

--- a/md5_mb/md5_mb_test.c
+++ b/md5_mb/md5_mb_test.c
@@ -88,8 +88,14 @@ int main(void)
 	MD5_HASH_CTX ctxpool[NUM_JOBS], *ctx = NULL;
 	uint32_t i, j, k, t, checked = 0;
 	uint32_t *good;
+	int ret;
 
-	posix_memalign((void *)&mgr, 16, sizeof(MD5_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(MD5_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	md5_ctx_mgr_init(mgr);
 
 	// Init contexts before first use

--- a/sha1_mb/sha1_mb_flush_test.c
+++ b/sha1_mb/sha1_mb_flush_test.c
@@ -77,10 +77,16 @@ int main(void)
 	unsigned char *bufs[TEST_BUFS];
 	uint32_t lens[TEST_BUFS];
 	uint8_t num_ret, num_unchanged = 0;
+	int ret;
 
 	printf("sha1_mb flush test, %d buffers with %d length: \n", TEST_BUFS, TEST_LEN);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha1_ctx_mgr_init(mgr);
 
 	srand(TEST_SEED);

--- a/sha1_mb/sha1_mb_rand_ssl_test.c
+++ b/sha1_mb/sha1_mb_rand_ssl_test.c
@@ -61,12 +61,18 @@ int main(void)
 	uint32_t i, j, fail = 0;
 	uint32_t lens[TEST_BUFS];
 	unsigned int jobs, t;
+	int ret;
 
 	printf("multibinary_sha1 test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS, TEST_LEN);
 
 	srand(TEST_SEED);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha1_ctx_mgr_init(mgr);
 
 	for (i = 0; i < TEST_BUFS; i++) {

--- a/sha1_mb/sha1_mb_rand_test.c
+++ b/sha1_mb/sha1_mb_rand_test.c
@@ -62,10 +62,16 @@ int main(void)
 	uint32_t lens[TEST_BUFS];
 	unsigned int jobs, t;
 	uint8_t *tmp_buf;
+	int ret;
 
 	printf("multibinary_sha1 test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS, TEST_LEN);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha1_ctx_mgr_init(mgr);
 
 	srand(TEST_SEED);

--- a/sha1_mb/sha1_mb_rand_update_test.c
+++ b/sha1_mb/sha1_mb_rand_update_test.c
@@ -73,13 +73,19 @@ int main(void)
 	unsigned char *buf_ptr[TEST_BUFS];
 	uint32_t lens[TEST_BUFS];
 	unsigned int joblen, jobs, t;
+	int ret;
 
 	printf("multibinary_sha1_update test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS,
 	       TEST_LEN);
 
 	srand(TEST_SEED);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha1_ctx_mgr_init(mgr);
 
 	for (i = 0; i < TEST_BUFS; i++) {

--- a/sha1_mb/sha1_mb_test.c
+++ b/sha1_mb/sha1_mb_test.c
@@ -92,8 +92,14 @@ int main(void)
 	SHA1_HASH_CTX ctxpool[NUM_JOBS], *ctx = NULL;
 	uint32_t i, j, k, t, checked = 0;
 	uint32_t *good;
+	int ret;
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha1_ctx_mgr_init(mgr);
 
 	// Init contexts before first use

--- a/sha1_mb/sha1_multi_buffer_example.c
+++ b/sha1_mb/sha1_multi_buffer_example.c
@@ -75,8 +75,13 @@ int main(void)
 	SHA1_HASH_CTX *p_job;
 	int i, checked = 0, failed = 0;
 	int n = sizeof(msgs) / sizeof(msgs[0]);
+	int ret;
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
 	// Initialize multi-buffer manager
 	sha1_ctx_mgr_init(mgr);
 

--- a/sha256_mb/sha256_mb_flush_test.c
+++ b/sha256_mb/sha256_mb_flush_test.c
@@ -77,10 +77,16 @@ int main(void)
 	unsigned char *bufs[TEST_BUFS];
 	uint32_t lens[TEST_BUFS];
 	uint8_t num_ret, num_unchanged = 0;
+	int ret;
 
 	printf("sha256_mb flush test, %d buffers with %d length: \n", TEST_BUFS, TEST_LEN);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA256_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA256_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha256_ctx_mgr_init(mgr);
 
 	srand(TEST_SEED);

--- a/sha256_mb/sha256_mb_rand_ssl_test.c
+++ b/sha256_mb/sha256_mb_rand_ssl_test.c
@@ -61,13 +61,19 @@ int main(void)
 	uint32_t i, j, fail = 0;
 	uint32_t lens[TEST_BUFS];
 	unsigned int jobs, t;
+	int ret;
 
 	printf("multibinary_sha256 test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS,
 	       TEST_LEN);
 
 	srand(TEST_SEED);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA256_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA256_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha256_ctx_mgr_init(mgr);
 
 	for (i = 0; i < TEST_BUFS; i++) {

--- a/sha256_mb/sha256_mb_rand_test.c
+++ b/sha256_mb/sha256_mb_rand_test.c
@@ -62,11 +62,17 @@ int main(void)
 	uint32_t lens[TEST_BUFS];
 	unsigned int jobs, t;
 	uint8_t *tmp_buf;
+	int ret;
 
 	printf("multibinary_sha256 test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS,
 	       TEST_LEN);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA256_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA256_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha256_ctx_mgr_init(mgr);
 
 	srand(TEST_SEED);

--- a/sha256_mb/sha256_mb_rand_update_test.c
+++ b/sha256_mb/sha256_mb_rand_update_test.c
@@ -73,13 +73,19 @@ int main(void)
 	unsigned char *buf_ptr[TEST_BUFS];
 	uint32_t lens[TEST_BUFS];
 	unsigned int joblen, jobs, t;
+	int ret;
 
 	printf("multibinary_sha256_update test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS,
 	       TEST_LEN);
 
 	srand(TEST_SEED);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA256_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA256_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha256_ctx_mgr_init(mgr);
 
 	for (i = 0; i < TEST_BUFS; i++) {

--- a/sha256_mb/sha256_mb_test.c
+++ b/sha256_mb/sha256_mb_test.c
@@ -100,8 +100,14 @@ int main(void)
 	SHA256_HASH_CTX ctxpool[NUM_JOBS], *ctx = NULL;
 	uint32_t i, j, k, t, checked = 0;
 	uint32_t *good;
+	int ret;
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA256_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA256_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha256_ctx_mgr_init(mgr);
 
 	// Init contexts before first use

--- a/sha512_mb/sha512_mb_rand_ssl_test.c
+++ b/sha512_mb/sha512_mb_rand_ssl_test.c
@@ -61,13 +61,19 @@ int main(void)
 	uint32_t i, j, fail = 0;
 	uint32_t lens[TEST_BUFS];
 	unsigned int jobs, t;
+	int ret;
 
 	printf("multibinary_sha512 test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS,
 	       TEST_LEN);
 
 	srand(TEST_SEED);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA512_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA512_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha512_ctx_mgr_init(mgr);
 
 	for (i = 0; i < TEST_BUFS; i++) {

--- a/sha512_mb/sha512_mb_rand_test.c
+++ b/sha512_mb/sha512_mb_rand_test.c
@@ -62,11 +62,17 @@ int main(void)
 	uint32_t lens[TEST_BUFS];
 	unsigned int jobs, t;
 	uint8_t *tmp_buf;
+	int ret;
 
 	printf("multibinary_sha512 test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS,
 	       TEST_LEN);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA512_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA512_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha512_ctx_mgr_init(mgr);
 
 	srand(TEST_SEED);

--- a/sha512_mb/sha512_mb_rand_update_test.c
+++ b/sha512_mb/sha512_mb_rand_update_test.c
@@ -73,13 +73,19 @@ int main(void)
 	unsigned char *buf_ptr[TEST_BUFS];
 	uint32_t lens[TEST_BUFS];
 	unsigned int joblen, jobs, t;
+	int ret;
 
 	printf("multibinary_sha512_update test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS,
 	       TEST_LEN);
 
 	srand(TEST_SEED);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA512_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA512_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha512_ctx_mgr_init(mgr);
 
 	for (i = 0; i < TEST_BUFS; i++) {

--- a/sha512_mb/sha512_mb_test.c
+++ b/sha512_mb/sha512_mb_test.c
@@ -124,8 +124,14 @@ int main(void)
 	SHA512_HASH_CTX ctxpool[NUM_JOBS], *ctx = NULL;
 	uint32_t i, j, k, t, checked = 0;
 	uint64_t *good;
+	int ret;
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA512_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA512_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha512_ctx_mgr_init(mgr);
 
 	// Init contexts before first use

--- a/sm3_mb/sm3_mb_flush_test.c
+++ b/sm3_mb/sm3_mb_flush_test.c
@@ -78,10 +78,16 @@ int main(void)
 	unsigned char *bufs[TEST_BUFS];
 	uint32_t lens[TEST_BUFS];
 	uint8_t num_ret, num_unchanged = 0;
+	int ret;
 
 	printf("sm3_mb flush test, %d buffers with %d length: \n", TEST_BUFS, TEST_LEN);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SM3_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SM3_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sm3_ctx_mgr_init(mgr);
 
 	srand(TEST_SEED);

--- a/sm3_mb/sm3_mb_rand_ssl_test.c
+++ b/sm3_mb/sm3_mb_rand_ssl_test.c
@@ -62,12 +62,18 @@ int main(void)
 	uint32_t i, j, fail = 0;
 	uint32_t lens[TEST_BUFS];
 	unsigned int jobs, t;
+	int ret;
 
 	printf("multibinary_sm3 test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS, TEST_LEN);
 
 	srand(TEST_SEED);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SM3_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SM3_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sm3_ctx_mgr_init(mgr);
 
 	for (i = 0; i < TEST_BUFS; i++) {

--- a/sm3_mb/sm3_mb_rand_test.c
+++ b/sm3_mb/sm3_mb_rand_test.c
@@ -63,10 +63,16 @@ int main(void)
 	uint32_t lens[TEST_BUFS];
 	unsigned int jobs, t;
 	uint8_t *tmp_buf;
+	int ret;
 
 	printf("multibinary_sm3 test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS, TEST_LEN);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SM3_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SM3_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sm3_ctx_mgr_init(mgr);
 
 	srand(TEST_SEED);

--- a/sm3_mb/sm3_mb_rand_update_test.c
+++ b/sm3_mb/sm3_mb_rand_update_test.c
@@ -72,13 +72,19 @@ int main(void)
 	unsigned char *buf_ptr[TEST_BUFS];
 	uint32_t lens[TEST_BUFS];
 	unsigned int joblen, jobs, t;
+	int ret;
 
 	printf("multibinary_sm3_update test, %d sets of %dx%d max: ", RANDOMS, TEST_BUFS,
 	       TEST_LEN);
 
 	srand(TEST_SEED);
 
-	posix_memalign((void *)&mgr, 16, sizeof(SM3_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SM3_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sm3_ctx_mgr_init(mgr);
 
 	for (i = 0; i < TEST_BUFS; i++) {

--- a/sm3_mb/sm3_ref_test.c
+++ b/sm3_mb/sm3_ref_test.c
@@ -65,8 +65,14 @@ int main(void)
 	SM3_HASH_CTX ctxpool[NUM_JOBS], *ctx = NULL;
 	uint32_t i, j, k, t, checked = 0;
 	uint32_t *good;
+	int ret;
 
-	posix_memalign((void *)&mgr, 16, sizeof(SM3_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SM3_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sm3_ctx_mgr_init(mgr);
 
 	// Init contexts before first use

--- a/tests/extended/md5_mb_over_4GB_test.c
+++ b/tests/extended/md5_mb_over_4GB_test.c
@@ -54,8 +54,13 @@ int main(void)
 	uint32_t i, j, k, fail = 0;
 	unsigned char *bufs[TEST_BUFS];
 	struct user_data udata[TEST_BUFS];
+	int ret;
 
-	posix_memalign((void *)&mgr, 16, sizeof(MD5_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(MD5_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
 	md5_ctx_mgr_init(mgr);
 
 	printf("md5_large_test\n");

--- a/tests/extended/sha1_mb_over_4GB_test.c
+++ b/tests/extended/sha1_mb_over_4GB_test.c
@@ -54,8 +54,14 @@ int main(void)
 	uint32_t i, j, k, fail = 0;
 	unsigned char *bufs[TEST_BUFS];
 	struct user_data udata[TEST_BUFS];
+	int ret;
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA1_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha1_ctx_mgr_init(mgr);
 
 	printf("sha1_large_test\n");

--- a/tests/extended/sha256_mb_over_4GB_test.c
+++ b/tests/extended/sha256_mb_over_4GB_test.c
@@ -54,8 +54,14 @@ int main(void)
 	uint32_t i, j, k, fail = 0;
 	unsigned char *bufs[TEST_BUFS];
 	struct user_data udata[TEST_BUFS];
+	int ret;
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA256_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA256_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha256_ctx_mgr_init(mgr);
 
 	printf("sha256_large_test\n");

--- a/tests/extended/sha512_mb_over_4GB_test.c
+++ b/tests/extended/sha512_mb_over_4GB_test.c
@@ -54,8 +54,14 @@ int main(void)
 	uint32_t i, j, k, fail = 0;
 	unsigned char *bufs[TEST_BUFS];
 	struct user_data udata[TEST_BUFS];
+	int ret;
 
-	posix_memalign((void *)&mgr, 16, sizeof(SHA512_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SHA512_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sha512_ctx_mgr_init(mgr);
 
 	printf("sha512_large_test\n");

--- a/tests/extended/sm3_mb_over_4GB_test.c
+++ b/tests/extended/sm3_mb_over_4GB_test.c
@@ -57,8 +57,14 @@ int main(void)
 	EVP_MD_CTX *md_ctx;
 	const EVP_MD *md;
 	unsigned int md_len;
+	int ret;
 
-	posix_memalign((void *)&mgr, 16, sizeof(SM3_HASH_CTX_MGR));
+	ret = posix_memalign((void *)&mgr, 16, sizeof(SM3_HASH_CTX_MGR));
+	if ((ret != 0) || (mgr == NULL)) {
+		printf("posix_memalign failed test aborted\n");
+		return 1;
+	}
+
 	sm3_ctx_mgr_init(mgr);
 
 	printf("sm3_large_test\n");


### PR DESCRIPTION
Also, use same return value when these fail (+1) as used when the output pointer
is NULL, rather than using -1. This avoids potential issues when results are
combined with with `errors += foo()`.

Change-Id: I0cfa73481315366cd3b8bd7f369fae55960a88a4
Signed-off-by: Tom Cosgrove <tom.cosgrove@arm.com>