### PR TITLE
Fix lane handling on aarch64 systems with SM3 hardware crypto support

### DIFF
--- a/sm3_mb/aarch64/sm3_mb_mgr_sm_aarch64.c
+++ b/sm3_mb/aarch64/sm3_mb_mgr_sm_aarch64.c
@@ -66,7 +66,7 @@ void sm3_mb_mgr_init_sm(SM3_MB_JOB_MGR * state)
 	state->num_lanes_inuse = 0;
 	for (i = 0; i < SM3_MB_CE_MAX_LANES; i++) {
 		state->unused_lanes <<= 4;
-		state->unused_lanes |= i;
+		state->unused_lanes |= SM3_MB_CE_MAX_LANES - 1 - i;
 		state->lens[i] = i;
 		state->ldata[i].job_in_lane = 0;
 	}


### PR DESCRIPTION
This fixes .unused_lanes to be initialised to (e.g.) 0xF3210 instead of
the current 0xF0123.

Without this, sm3_mb_rand_update_test and sm3_mb_vs_ossl_perf spin in
infinite loops calling sm3_ctx_mgr_submit().

Change-Id: I878228481408d4d5c34724ff1170e10670a4c48c
Signed-off-by: Tom Cosgrove <tom.cosgrove@arm.com>