### PR TITLE
Fix clang attribute for missing pop

### DIFF
--- a/md5_mb/md5_ctx_avx512.c
+++ b/md5_mb/md5_ctx_avx512.c
@@ -260,8 +260,8 @@ struct slver md5_ctx_mgr_submit_avx512_slver = { 0x018d, 0x00, 0x06 };
 struct slver md5_ctx_mgr_flush_avx512_slver_0600018e;
 struct slver md5_ctx_mgr_flush_avx512_slver = { 0x018e, 0x00, 0x06 };
 
+#endif // HAVE_AS_KNOWS_AVX512
+
 #if defined(__clang__)
 # pragma clang attribute pop
 #endif
-
-#endif // HAVE_AS_KNOWS_AVX512


### PR DESCRIPTION
One clang attribute pop was inadvertently placed inside an ifdef where
the push was outside. Fixes error with clang and yasm or when
assembler doesn't know avx512.

Fixes #88

Change-Id: Ieb4aeae453bd13d0c5178309c0b0c73b96e82cf0
Signed-off-by: Greg Tucker <greg.b.tucker@intel.com>