### PR TITLE
Fix the build issue for CPU other than x86/aarch64

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,15 @@ include mh_sha1_murmur3_x64_128/Makefile.am
 include mh_sha256/Makefile.am
 include rolling_hash/Makefile.am
 include sm3_mb/Makefile.am
+if CPU_X86_64
 include aes/Makefile.am
+endif
+if CPU_X86_32
+include aes/Makefile.am
+endif
+if CPU_AARCH64
+include aes/Makefile.am
+endif
 
 # LIB version info not necessarily the same as package version
 LIBISAL_CURRENT=2

--- a/Makefile.unx
+++ b/Makefile.unx
@@ -33,11 +33,14 @@ arch ?= $(shell uname | grep -v -e Linux -e BSD )
 
 units ?=sha1_mb sha256_mb sha512_mb md5_mb mh_sha1 mh_sha1_murmur3_x64_128 \
 	mh_sha256 rolling_hash sm3_mb
+ifneq ($(filter x86_%,$(host_cpu)),)
 ifneq ($(arch),noarch)
 units +=aes
 endif
+endif
 ifeq ($(host_cpu)_$(arch),aarch64_)
   arch = aarch64
+  units +=aes
 endif
 default: lib
 include $(foreach unit,$(units), $(unit)/Makefile.am)


### PR DESCRIPTION
AES acceleration is not implemented for other CPU, like ppc64, etc
AES related function can't compile on these platforms

Signed-off-by: Daniel Hu <Daniel.Hu@arm.com>