### PR TITLE
Acceleration of md5-mb for aarch64 by SVE

### DIFF
--- a/md5_mb/Makefile.am
+++ b/md5_mb/Makefile.am
@@ -60,8 +60,10 @@ lsrc_aarch64 += md5_mb/md5_ctx_base.c \
 		md5_mb/aarch64/md5_mb_mgr_aarch64_asimd.c  \
 		md5_mb/aarch64/md5_mb_asimd_x4.S  \
 		md5_mb/aarch64/md5_mb_asimd_x1.S  \
+		md5_mb/aarch64/md5_ctx_aarch64_sve.c  \
+		md5_mb/aarch64/md5_mb_mgr_aarch64_sve.c  \
+		md5_mb/aarch64/md5_mb_sve.S  \
 		md5_mb/aarch64/md5_mb_multibinary.S
-
 
 lsrc_base_aliases += md5_mb/md5_ctx_base.c \
 		md5_mb/md5_ctx_base_aliases.c

--- a/md5_mb/aarch64/md5_ctx_aarch64_sve.c
+++ b/md5_mb/aarch64/md5_ctx_aarch64_sve.c
@@ -1,0 +1,229 @@
+/**********************************************************************
+  Copyright(c) 2022 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stdlib.h>
+#include "md5_mb.h"
+#include "memcpy_inline.h"
+void md5_mb_mgr_init_sve(MD5_MB_JOB_MGR * state);
+MD5_JOB *md5_mb_mgr_submit_sve(MD5_MB_JOB_MGR * state, MD5_JOB * job);
+MD5_JOB *md5_mb_mgr_flush_sve(MD5_MB_JOB_MGR * state);
+
+static inline void hash_init_digest(MD5_WORD_T * digest);
+static inline uint32_t hash_pad(uint8_t padblock[MD5_BLOCK_SIZE * 2], uint64_t total_len);
+static MD5_HASH_CTX *md5_ctx_mgr_resubmit(MD5_HASH_CTX_MGR * mgr, MD5_HASH_CTX * ctx);
+
+void md5_ctx_mgr_init_sve(MD5_HASH_CTX_MGR * mgr)
+{
+	md5_mb_mgr_init_sve(&mgr->mgr);
+}
+
+MD5_HASH_CTX *md5_ctx_mgr_submit_sve(MD5_HASH_CTX_MGR * mgr, MD5_HASH_CTX * ctx,
+				     const void *buffer, uint32_t len, HASH_CTX_FLAG flags)
+{
+	if (flags & (~HASH_ENTIRE)) {
+		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
+	}
+
+	if (ctx->status & HASH_CTX_STS_PROCESSING) {
+		// Cannot submit to a currently processing job.
+		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
+	}
+
+	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
+		// Cannot update a finished job.
+		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
+	}
+
+	if (flags & HASH_FIRST) {
+		// Init digest
+		hash_init_digest(ctx->job.result_digest);
+
+		// Reset byte counter
+		ctx->total_length = 0;
+
+		// Clear extra blocks
+		ctx->partial_block_buffer_length = 0;
+	}
+	// If we made it here, there were no errors during this call to submit
+	ctx->error = HASH_CTX_ERROR_NONE;
+
+	// Store buffer ptr info from user
+	ctx->incoming_buffer = buffer;
+	ctx->incoming_buffer_length = len;
+
+	// Store the user's request flags and mark this ctx as currently being processed.
+	ctx->status = (flags & HASH_LAST) ?
+	    (HASH_CTX_STS) (HASH_CTX_STS_PROCESSING | HASH_CTX_STS_LAST) :
+	    HASH_CTX_STS_PROCESSING;
+
+	// Advance byte counter
+	ctx->total_length += len;
+
+	// If there is anything currently buffered in the extra blocks, append to it until it contains a whole block.
+	// Or if the user's buffer contains less than a whole block, append as much as possible to the extra block.
+	if ((ctx->partial_block_buffer_length) | (len < MD5_BLOCK_SIZE)) {
+		// Compute how many bytes to copy from user buffer into extra block
+		uint32_t copy_len = MD5_BLOCK_SIZE - ctx->partial_block_buffer_length;
+		if (len < copy_len)
+			copy_len = len;
+
+		if (copy_len) {
+			// Copy and update relevant pointers and counters
+			memcpy_varlen(&ctx->partial_block_buffer
+				      [ctx->partial_block_buffer_length], buffer, copy_len);
+
+			ctx->partial_block_buffer_length += copy_len;
+			ctx->incoming_buffer = (const void *)((const char *)buffer + copy_len);
+			ctx->incoming_buffer_length = len - copy_len;
+		}
+		// The extra block should never contain more than 1 block here
+		assert(ctx->partial_block_buffer_length <= MD5_BLOCK_SIZE);
+
+		// If the extra block buffer contains exactly 1 block, it can be hashed.
+		if (ctx->partial_block_buffer_length >= MD5_BLOCK_SIZE) {
+			ctx->partial_block_buffer_length = 0;
+
+			ctx->job.buffer = ctx->partial_block_buffer;
+			ctx->job.len = 1;
+			ctx = (MD5_HASH_CTX *) md5_mb_mgr_submit_sve(&mgr->mgr, &ctx->job);
+		}
+	}
+
+	return md5_ctx_mgr_resubmit(mgr, ctx);
+}
+
+MD5_HASH_CTX *md5_ctx_mgr_flush_sve(MD5_HASH_CTX_MGR * mgr)
+{
+	MD5_HASH_CTX *ctx;
+
+	while (1) {
+		ctx = (MD5_HASH_CTX *) md5_mb_mgr_flush_sve(&mgr->mgr);
+
+		// If flush returned 0, there are no more jobs in flight.
+		if (!ctx)
+			return NULL;
+
+		// If flush returned a job, verify that it is safe to return to the user.
+		// If it is not ready, resubmit the job to finish processing.
+		ctx = md5_ctx_mgr_resubmit(mgr, ctx);
+
+		// If md5_ctx_mgr_resubmit returned a job, it is ready to be returned.
+		if (ctx)
+			return ctx;
+
+		// Otherwise, all jobs currently being managed by the HASH_CTX_MGR still need processing. Loop.
+	}
+}
+
+static MD5_HASH_CTX *md5_ctx_mgr_resubmit(MD5_HASH_CTX_MGR * mgr, MD5_HASH_CTX * ctx)
+{
+	while (ctx) {
+
+		if (ctx->status & HASH_CTX_STS_COMPLETE) {
+			ctx->status = HASH_CTX_STS_COMPLETE;	// Clear PROCESSING bit
+			return ctx;
+		}
+		// If the extra blocks are empty, begin hashing what remains in the user's buffer.
+		if (ctx->partial_block_buffer_length == 0 && ctx->incoming_buffer_length) {
+			const void *buffer = ctx->incoming_buffer;
+			uint32_t len = ctx->incoming_buffer_length;
+
+			// Only entire blocks can be hashed. Copy remainder to extra blocks buffer.
+			uint32_t copy_len = len & (MD5_BLOCK_SIZE - 1);
+
+			if (copy_len) {
+				len -= copy_len;
+				memcpy_varlen(ctx->partial_block_buffer,
+					      ((const char *)buffer + len), copy_len);
+				ctx->partial_block_buffer_length = copy_len;
+			}
+
+			ctx->incoming_buffer_length = 0;
+
+			// len should be a multiple of the block size now
+			assert((len % MD5_BLOCK_SIZE) == 0);
+
+			// Set len to the number of blocks to be hashed in the user's buffer
+			len >>= MD5_LOG2_BLOCK_SIZE;
+
+			if (len) {
+				ctx->job.buffer = (uint8_t *) buffer;
+				ctx->job.len = len;
+				ctx = (MD5_HASH_CTX *) md5_mb_mgr_submit_sve(&mgr->mgr,
+									     &ctx->job);
+				continue;
+			}
+		}
+		// If the extra blocks are not empty, then we are either on the last block(s)
+		// or we need more user input before continuing.
+		if (ctx->status & HASH_CTX_STS_LAST) {
+
+			uint8_t *buf = ctx->partial_block_buffer;
+			uint32_t n_extra_blocks = hash_pad(buf, ctx->total_length);
+
+			ctx->status =
+			    (HASH_CTX_STS) (HASH_CTX_STS_PROCESSING | HASH_CTX_STS_COMPLETE);
+
+			ctx->job.buffer = buf;
+			ctx->job.len = n_extra_blocks;
+			ctx = (MD5_HASH_CTX *) md5_mb_mgr_submit_sve(&mgr->mgr, &ctx->job);
+			continue;
+		}
+
+		if (ctx)
+			ctx->status = HASH_CTX_STS_IDLE;
+		return ctx;
+	}
+
+	return NULL;
+}
+
+static inline void hash_init_digest(MD5_WORD_T * digest)
+{
+	static const MD5_WORD_T hash_initial_digest[MD5_DIGEST_NWORDS] =
+	    { MD5_INITIAL_DIGEST };
+	memcpy_fixedlen(digest, hash_initial_digest, sizeof(hash_initial_digest));
+}
+
+static inline uint32_t hash_pad(uint8_t padblock[MD5_BLOCK_SIZE * 2], uint64_t total_len)
+{
+	uint32_t i = (uint32_t) (total_len & (MD5_BLOCK_SIZE - 1));
+
+	memclr_fixedlen(&padblock[i], MD5_BLOCK_SIZE);
+	padblock[i] = 0x80;
+
+	i += ((MD5_BLOCK_SIZE - 1) & (0 - (total_len + MD5_PADLENGTHFIELD_SIZE + 1))) + 1 +
+	    MD5_PADLENGTHFIELD_SIZE;
+
+	*((uint64_t *) & padblock[i - 8]) = ((uint64_t) total_len << 3);
+
+	return i >> MD5_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
+}

--- a/md5_mb/aarch64/md5_mb_mgr_aarch64_sve.c
+++ b/md5_mb/aarch64/md5_mb_mgr_aarch64_sve.c
@@ -1,0 +1,213 @@
+/**********************************************************************
+  Copyright(c) 2022 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stddef.h>
+#include <md5_mb.h>
+#include <assert.h>
+
+#ifndef min
+#define min(a,b)            (((a) < (b)) ? (a) : (b))
+#endif
+
+extern void md5_mb_sve(int blocks, int total_lanes, MD5_JOB **);
+extern void md5_mb_asimd_x4(MD5_JOB *, MD5_JOB *, MD5_JOB *, MD5_JOB *, int);
+extern void md5_mb_asimd_x1(MD5_JOB *, int);
+extern int md5_mb_sve_max_lanes(void);
+
+#define LANE_IS_NOT_FINISHED(state,i)  	\
+	(((state->lens[i]&(~0xff))!=0) && state->ldata[i].job_in_lane!=NULL)
+#define LANE_IS_FINISHED(state,i)  	\
+	(((state->lens[i]&(~0xff))==0) && state->ldata[i].job_in_lane!=NULL)
+#define	LANE_IS_FREE(state,i)		\
+	(((state->lens[i]&(~0xff))==0) && state->ldata[i].job_in_lane==NULL)
+#define LANE_IS_INVALID(state,i)	\
+	(((state->lens[i]&(~0xff))!=0) && state->ldata[i].job_in_lane==NULL)
+void md5_mb_mgr_init_sve(MD5_MB_JOB_MGR * state)
+{
+	unsigned int j;
+	state->unused_lanes[0] = 0x0706050403020100;
+	state->unused_lanes[1] = 0x0f0e0d0c0b0a0908;
+	state->unused_lanes[2] = 0x1716151413121110;
+	state->unused_lanes[3] = 0x1f1e1d1c1b1a1918;
+	state->num_lanes_inuse = 0;
+	for (j = 0; j < MD5_MAX_LANES; j++) {
+		state->lens[j] = j;
+		state->ldata[j].job_in_lane = 0;
+	}
+}
+
+static int md5_mb_mgr_do_jobs(MD5_MB_JOB_MGR * state)
+{
+	int lane_idx, len, i, lanes, blocks;
+	MD5_JOB *job_vecs[MD5_MAX_LANES];
+	int maxjobs;
+
+	if (state->num_lanes_inuse == 0) {
+		return -1;
+	}
+
+	maxjobs = md5_mb_sve_max_lanes();
+	if (maxjobs > MD5_MAX_LANES)
+		maxjobs = MD5_MAX_LANES;
+
+	lanes = 0;
+	len = 0;
+	for (i = 0; i < MD5_MAX_LANES && lanes < state->num_lanes_inuse; i++) {
+		if (LANE_IS_NOT_FINISHED(state, i)) {
+			if (lanes)
+				len = min(len, state->lens[i]);
+			else
+				len = state->lens[i];
+			job_vecs[lanes++] = state->ldata[i].job_in_lane;
+		}
+	}
+
+	if (lanes == 0)
+		return -1;
+	lane_idx = len & 0xff;
+	len &= ~0xff;
+	blocks = len >> 8;
+
+	// current SVE implementation leverage double pipeline in parallel
+	// based on current V1 micro-architecture test, it is found SVE
+	// do not perform well (that is, better than neon) if the number
+	// lanes is less than single vector capacity minus 2
+	// Things might change for future micro-architecture
+	if (lanes >= maxjobs / 2 - 2) {
+		md5_mb_sve(blocks, lanes, job_vecs);
+	} else {
+		i = 0;
+		while (i + 3 < lanes) {
+			md5_mb_asimd_x4(job_vecs[i], job_vecs[i + 1],
+					job_vecs[i + 2], job_vecs[i + 3], blocks);
+			i += 4;
+		}
+
+		while (i < lanes) {
+			md5_mb_asimd_x1(job_vecs[i++], blocks);
+		}
+	}
+
+	for (i = 0; i < MD5_MAX_LANES; i++) {
+		if (LANE_IS_NOT_FINISHED(state, i)) {
+			state->lens[i] -= len;
+			state->ldata[i].job_in_lane->len -= (blocks << 6);
+			state->ldata[i].job_in_lane->buffer += (blocks << 6);
+		}
+	}
+
+	return lane_idx;
+}
+
+static MD5_JOB *md5_mb_mgr_free_lane(MD5_MB_JOB_MGR * state)
+{
+	int i;
+	MD5_JOB *ret = NULL;
+
+	for (i = 0; i < MD5_MAX_LANES; i++) {
+		if (LANE_IS_FINISHED(state, i)) {
+			int grp = i / 8;
+			state->unused_lanes[grp] <<= 8;
+			state->unused_lanes[grp] |= i;
+			state->num_lanes_inuse--;
+			ret = state->ldata[i].job_in_lane;
+			ret->status = STS_COMPLETED;
+			state->ldata[i].job_in_lane = NULL;
+			break;
+		}
+	}
+	return ret;
+}
+
+static void md5_mb_mgr_insert_job(MD5_MB_JOB_MGR * state, MD5_JOB * job)
+{
+	int grp = 0;
+	int lane_idx;
+
+	for (int i = 0; i < MD5_MAX_LANES; i++) {
+		if (LANE_IS_FREE(state, i)) {
+			grp = i / 8;
+			break;
+		}
+	}
+
+	//add job into lanes
+	lane_idx = state->unused_lanes[grp] & 0xff;
+
+	//fatal error
+	assert(lane_idx < MD5_MAX_LANES);
+	state->lens[lane_idx] = (job->len << 8) | lane_idx;
+	state->ldata[lane_idx].job_in_lane = job;
+	state->unused_lanes[grp] >>= 8;
+	state->num_lanes_inuse++;
+}
+
+MD5_JOB *md5_mb_mgr_submit_sve(MD5_MB_JOB_MGR * state, MD5_JOB * job)
+{
+#ifndef NDEBUG
+	int lane_idx;
+#endif
+	MD5_JOB *ret;
+	int maxjobs = md5_mb_sve_max_lanes();
+
+	if (maxjobs > MD5_MAX_LANES)
+		maxjobs = MD5_MAX_LANES;
+
+	//add job into lanes
+	md5_mb_mgr_insert_job(state, job);
+
+	ret = md5_mb_mgr_free_lane(state);
+	if (ret != NULL) {
+		return ret;
+	}
+	//submit will wait all lane has data
+	if (state->num_lanes_inuse < maxjobs)
+		return NULL;
+#ifndef NDEBUG
+	lane_idx = md5_mb_mgr_do_jobs(state);
+	assert(lane_idx != -1);
+#else
+	md5_mb_mgr_do_jobs(state);
+#endif
+
+	ret = md5_mb_mgr_free_lane(state);
+	return ret;
+}
+
+MD5_JOB *md5_mb_mgr_flush_sve(MD5_MB_JOB_MGR * state)
+{
+	MD5_JOB *ret;
+
+	ret = md5_mb_mgr_free_lane(state);
+	if (ret) {
+		return ret;
+	}
+
+	md5_mb_mgr_do_jobs(state);
+	return md5_mb_mgr_free_lane(state);
+}

--- a/md5_mb/aarch64/md5_mb_sve.S
+++ b/md5_mb/aarch64/md5_mb_sve.S
@@ -1,0 +1,158 @@
+/**********************************************************************
+  Copyright(c) 2022 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+	.arch armv8.2-a+sve
+
+// copying data from sparse memory unto continous stack space
+// in oroder to gather-load into SVE registers
+.macro copy_mb_16words vecs:req,dest:req
+	mov	src,\vecs
+	mov	dst,\dest
+	mov	counter,total_lanes
+10:
+	ldr	tmp,[src],8
+	ldr	tmp,[tmp]
+	add	tmp,tmp,block_ctr,lsl 6
+	ld1	{TMPV0.4s,TMPV1.4s,TMPV2.4s,TMPV3.4s}, [tmp]
+	st1	{TMPV0.4s,TMPV1.4s,TMPV2.4s,TMPV3.4s}, [dst],64
+	subs	counter,counter,1
+	b.ne	10b
+.endm
+
+.macro load_init
+	mov	tmpw,16
+	index VOFFS.s,0,tmpw
+	copy_mb_16words	job_vec,databuf
+.endm
+
+.macro load_word pipelines:req,windex:req,zreg0:req,zreg1
+	add	tmp,databuf,\windex * 4
+	ld1w	{ \zreg0\().s}, p0/z, [tmp, VOFFS.s, UXTW 2]
+	.if	\pipelines > 1
+		add	tmp,tmp,veclen,lsl #6
+		ld1w	{\zreg1\().s}, p1/z, [tmp, VOFFS.s, UXTW 2]
+	.endif
+.endm
+
+#include "md5_sve_common.S"
+
+/* int md5_mb_sve_max_lanes()
+ */
+	.global md5_mb_sve_max_lanes
+	.type md5_mb_sve_max_lanes, %function
+md5_mb_sve_max_lanes:
+	cntw	x0
+	add	x0,x0,x0
+	ret
+	.size md5_mb_sve_max_lanes, .-md5_mb_sve_max_lanes
+
+/*
+ *  void md5_mb_sve(int blocks, int total_lanes, MD5_JOB **job_vec)
+ */
+	num_blocks	.req	w0
+	total_lanes	.req	w1
+	job_vec	.req	x2
+	src	.req	x5
+	dst	.req	x6
+	tmp	.req	x8
+	tmpw	.req	w8
+	block_ctr	.req	x9
+	block_ctr_w	.req	w9
+	savedsp	.req	x10
+	databuf	.req	x11
+	counter	.req	w12
+	veclen	.req	x13
+	veclen_w	.req	w13
+	abcd_buf	.req	x14
+	md5key_adr	.req	x15
+
+	.global md5_mb_sve
+	.type md5_mb_sve, %function
+md5_mb_sve:
+	cbz	num_blocks,.return
+	md5_sve_save_stack
+	mov	savedsp,sp
+	// reserve (16 * lanes) for abcd buf
+	mov	tmpw,total_lanes,lsl 4
+	sub	abcd_buf,sp,tmp
+	// reserve (64 * lanes) for data buf
+	mov	tmpw,total_lanes,lsl 6
+	sub	databuf,abcd_buf,tmp
+	mov	sp,databuf
+	adr	md5key_adr,MD5_CONST_KEYS
+	whilelo	p0.s,wzr,total_lanes
+	mov	src,job_vec
+	mov	dst,abcd_buf
+	mov	counter,total_lanes
+.ldr_hash:
+	ldr	tmp,[src],8
+	add	tmp,tmp,64
+	ld1	{v0.16b},[tmp]
+	st1	{v0.16b},[dst],16
+	subs	counter,counter,1
+	bne	.ldr_hash
+	ld4w	{VA_0.s,VB_0.s,VC_0.s,VD_0.s},p0/z,[abcd_buf]
+	mov	block_ctr,0
+	cntp	veclen,p0,p0.s
+	cmp	veclen_w,total_lanes
+	b.eq	.loop_1x
+	whilelo	p1.s,veclen_w,total_lanes
+	add	tmp,abcd_buf,veclen,lsl #4
+	ld4w	{VA_1.s,VB_1.s,VC_1.s,VD_1.s},p1/z,[tmp]
+	b	.loop_2x
+.loop_1x:
+	md5_single	1
+	add	block_ctr, block_ctr, 1
+	cmp	block_ctr_w,num_blocks
+	bne	.loop_1x
+	st4w	{VA_0.s,VB_0.s,VC_0.s,VD_0.s},p0,[abcd_buf]
+	b	1f
+.loop_2x:
+	md5_single	2
+	add	block_ctr, block_ctr, 1
+	cmp	block_ctr_w,num_blocks
+	bne	.loop_2x
+	st4w	{VA_0.s,VB_0.s,VC_0.s,VD_0.s},p0,[abcd_buf]
+	add	tmp,abcd_buf,veclen,lsl #4
+	st4w	{VA_1.s,VB_1.s,VC_1.s,VD_1.s},p1,[tmp]
+1:
+	mov	dst,job_vec
+	mov	src,abcd_buf
+.str_hash:
+	ld1	{v0.16b},[src],16
+	ldr	tmp,[dst],8
+	add	tmp,tmp,64
+	st1	{v0.16b},[tmp]
+	subs	total_lanes,total_lanes,1
+	bne	.str_hash
+	mov	sp,savedsp
+	md5_sve_restore_stack
+.return:
+	ret
+	.size md5_mb_sve, .-md5_mb_sve

--- a/md5_mb/aarch64/md5_sve_common.S
+++ b/md5_mb/aarch64/md5_sve_common.S
@@ -1,0 +1,473 @@
+/**********************************************************************
+  Copyright(c) 2022 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+	VK	.req z0
+	VOFFS	.req z1
+	VA_0	.req z2
+	VB_0	.req z3
+	VC_0	.req z4
+	VD_0	.req z5
+	VF_0	.req z6
+	VF_1	.req z7
+	VA_1	.req z16
+	VB_1	.req z17
+	VC_1	.req z18
+	VD_1	.req z19
+	MD5WORD0_0	.req z20
+	MD5WORD1_0	.req z21
+	MD5WORD0_1	.req z22
+	MD5WORD1_1	.req z23
+	TMPV0	.req v20
+	TMPV1	.req v21
+	TMPV2	.req v22
+	TMPV3	.req v23
+	VTMP_0	.req z24
+	VAA_0	.req z25
+	VBB_0	.req z26
+	VCC_0	.req z27
+	VDD_0	.req z28
+	VTMP_1	.req z29
+	VAA_1	.req z30
+	VBB_1	.req z31
+	VCC_1	.req z8
+	VDD_1	.req z9
+	TT	.req z0
+
+.macro rotate_left_x1	out:req,in:req,tmp:req,bits
+	.if \bits == 16
+		revh	\out\().s,p0/m,\in\().s
+	.else
+		.if have_sve2 == 0
+			lsl	\tmp\().s, \in\().s,\bits
+			lsr	\out\().s,\in\().s,32-\bits
+			orr	\out\().d,\out\().d,\tmp\().d
+		.else
+			movprfx	\out\().d,\in\().d
+			xar	\out\().s,\out\().s,VZERO.s,32-\bits
+		.endif
+	.endif
+.endm
+
+.macro rotate_left_x2	out:req,in:req,tmp:req,bits,out1:req,in1:req,tmp1:req,bits1
+
+	.if \bits == 16
+		revh	\out\().s,p0/m,\in\().s
+		revh	\out1\().s,p0/m,\in1\().s
+	.else
+		.if have_sve2 == 0
+			lsl	\tmp\().s, \in\().s,\bits
+			lsl	\tmp1\().s, \in1\().s,\bits1
+			lsr	\out\().s,\in\().s,32-\bits
+			lsr	\out1\().s,\in1\().s,32-\bits1
+			orr	\out\().d,\out\().d,\tmp\().d
+			orr	\out1\().d,\out1\().d,\tmp1\().d
+		.else
+			movprfx	\out\().d,\in\().d
+			xar	\out\().s,\out\().s,VZERO.s,32-\bits
+			movprfx	\out1\().d,\in1\().d
+			xar	\out1\().s,\out1\().s,VZERO.s,32-\bits1
+		.endif
+	.endif
+.endm
+
+.macro bsl_x1	ret:req,x:req,y:req,z:req,tmp:req
+	.if have_sve2 == 0
+		bic	\ret\().d,\z\().d,\x\().d
+		and	\tmp\().d,\x\().d,\y\().d
+		orr	\ret\().d,\ret\().d,\tmp\().d
+	.else
+		movprfx	\ret\().d,\x\().d
+		bsl	\ret\().d,\ret\().d,\y\().d,\z\().d
+	.endif
+.endm
+
+.macro bsl_x2	ret:req,x:req,y:req,z:req,tmp:req,ret1:req,x1:req,y1:req,z1:req,tmp1:req
+	.if have_sve2 == 0
+		bic	\ret\().d,\z\().d,\x\().d
+		bic	\ret1\().d,\z1\().d,\x1\().d
+		and	\tmp\().d,\x\().d,\y\().d
+		and	\tmp1\().d,\x1\().d,\y1\().d
+		orr	\ret\().d,\ret\().d,\tmp\().d
+		orr	\ret1\().d,\ret1\().d,\tmp1\().d
+	.else
+		movprfx	\ret\().d,\x\().d
+		bsl	\ret\().d,\ret\().d,\y\().d,\z\().d
+		movprfx	\ret1\().d,\x1\().d
+		bsl	\ret1\().d,\ret1\().d,\y1\().d,\z1\().d
+	.endif
+.endm
+
+
+// F = D ^ (B and (C xor D))
+// that is (B and C) or ((not B) and D)
+.macro FUNC_F0_x1
+	bsl_x1	VF_0,VB_0,VC_0,VD_0,VTMP_0
+.endm
+
+.macro FUNC_F0_x2
+	bsl_x2	VF_0,VB_0,VC_0,VD_0,VTMP_0,VF_1,VB_1,VC_1,VD_1,VTMP_1
+.endm
+
+// F = C xor (D and (B xor C))
+// that is (D and B) or ((not D) and C)
+.macro FUNC_F1_x1
+	bsl_x1	VF_0,VD_0,VB_0,VC_0,VTMP_0
+.endm
+
+.macro FUNC_F1_x2
+	bsl_x2	VF_0,VD_0,VB_0,VC_0,VTMP_0,VF_1,VD_1,VB_1,VC_1,VTMP_1
+.endm
+
+// F := B xor C xor D
+.macro FUNC_F2_x1
+	.if have_sve2 == 0
+		eor	VF_0.d,VB_0.d,VC_0.d
+		eor	VF_0.d,VF_0.d,VD_0.d
+	.else
+		movprfx	VF_0.d,VB_0.d
+		eor3	VF_0.d,VF_0.d,VC_0.d,VD_0.d
+	.endif
+.endm
+
+.macro FUNC_F2_x2
+	.if have_sve2 == 0
+		eor	VF_0.d,VB_0.d,VC_0.d
+		eor	VF_1.d,VB_1.d,VC_1.d
+		eor	VF_0.d,VF_0.d,VD_0.d
+		eor	VF_1.d,VF_1.d,VD_1.d
+	.else
+		movprfx	VF_0.d,VB_0.d
+		eor3	VF_0.d,VF_0.d,VC_0.d,VD_0.d
+		movprfx	VF_1.d,VB_1.d
+		eor3	VF_1.d,VF_1.d,VC_1.d,VD_1.d
+	.endif
+.endm
+
+// F := C xor (B or (not D))
+.macro FUNC_F3_x1
+	not	VF_0.s,p0/m,VD_0.s
+	orr	VF_0.d,VF_0.d,VB_0.d
+	eor	VF_0.d,VF_0.d,VC_0.d
+.endm
+
+.macro FUNC_F3_x2
+	not	VF_0.s,p0/m,VD_0.s
+	not	VF_1.s,p0/m,VD_1.s
+	orr	VF_0.d,VF_0.d,VB_0.d
+	orr	VF_1.d,VF_1.d,VB_1.d
+	eor	VF_0.d,VF_0.d,VC_0.d
+	eor	VF_1.d,VF_1.d,VC_1.d
+.endm
+
+.macro SWAP_STATES
+	.unreq TT
+	TT .req VA_0
+	.unreq VA_0
+	VA_0 .req VD_0
+	.unreq VD_0
+	VD_0 .req VC_0
+	.unreq VC_0
+	VC_0 .req VB_0
+	.unreq VB_0
+	VB_0 .req TT
+
+	.unreq TT
+	TT .req VA_1
+	.unreq VA_1
+	VA_1 .req VD_1
+	.unreq VD_1
+	VD_1 .req VC_1
+	.unreq VC_1
+	VC_1 .req VB_1
+	.unreq VB_1
+	VB_1 .req TT
+.endm
+
+.macro MD5_STEP_x1	windex:req,mg:req,func_f:req,bits:req
+	ld1rw	{VK.s},p0/z,[md5key_adr,windex * 4]
+	\func_f\()_x1
+	add	VTMP_0.s,VA_0.s,\mg\()_0.s
+	add	VF_0.s,VF_0.s,VK.s
+	add	VF_0.s,VF_0.s,VTMP_0.s
+	rotate_left_x1	VA_0,VF_0,VTMP_0,\bits
+	add	VA_0.s,VA_0.s,VB_0.s
+.endm
+
+.macro MD5_STEP_x2	windex:req,mg:req,func_f:req,bits:req
+	ld1rw	{VK.s},p0/z,[md5key_adr,windex * 4]
+	\func_f\()_x2
+	add	VTMP_0.s,VA_0.s,\mg\()_0.s
+	add	VTMP_1.s,VA_1.s,\mg\()_1.s
+	add	VF_0.s,VF_0.s,VK.s
+	add	VF_1.s,VF_1.s,VK.s
+	add	VF_0.s,VF_0.s,VTMP_0.s
+	add	VF_1.s,VF_1.s,VTMP_1.s
+	rotate_left_x2	VA_0,VF_0,VTMP_0,\bits,VA_1,VF_1,VTMP_1,\bits
+	add	VA_0.s,VA_0.s,VB_0.s
+	add	VA_1.s,VA_1.s,VB_1.s
+.endm
+
+.altmacro
+.macro load_words	index:req,mg:req
+	load_word	%num_pipelines,\index,MD5WORD\mg\()_0,MD5WORD\mg\()_1
+.endm
+
+.macro MD5_STEP_WRAPPER pipelines:req,windex:req,gindex:req,mg:req,func_f:req,bits:req,gindex_next,mg_next
+	.ifnb \gindex_next
+		load_words	\gindex_next,\mg_next
+	.endif
+	MD5_STEP_x\pipelines\()	\windex,MD5WORD\mg\(),\func_f,\bits
+.endm
+
+.macro exec_step windex:req,gindex:req,bits:req,gindex_next
+	.if \windex % 2 == 0
+		mg=0
+		mg_next=1
+	.else
+		mg=1
+		mg_next=0
+	.endif
+
+	.if \windex <= 15
+		MD5_STEP_WRAPPER	%num_pipelines,\windex,\gindex,%mg,FUNC_F0,\bits,\gindex_next,%mg_next
+	.endif
+	.if \windex >= 16 && \windex <= 31
+		MD5_STEP_WRAPPER	%num_pipelines,\windex,\gindex,%mg,FUNC_F1,\bits,\gindex_next,%mg_next
+	.endif
+	.if \windex >= 32 && \windex <= 47
+		MD5_STEP_WRAPPER	%num_pipelines,\windex,\gindex,%mg,FUNC_F2,\bits,\gindex_next,%mg_next
+	.endif
+	.if \windex >= 48 && \windex < 63
+		MD5_STEP_WRAPPER	%num_pipelines,\windex,\gindex,%mg,FUNC_F3,\bits,\gindex_next,%mg_next
+	.endif
+	.if \windex == 63
+		MD5_STEP_WRAPPER	%num_pipelines,\windex,\gindex,%mg,FUNC_F3,\bits
+	.endif
+	SWAP_STATES
+.endm
+
+.macro exec_steps
+	exec_step 0,0,7,1
+	exec_step 1,1,12,2
+	exec_step 2,2,17,3
+	exec_step 3,3,22,4
+	exec_step 4,4,7,5
+	exec_step 5,5,12,6
+	exec_step 6,6,17,7
+	exec_step 7,7,22,8
+	exec_step 8,8,7,9
+	exec_step 9,9,12,10
+	exec_step 10,10,17,11
+	exec_step 11,11,22,12
+	exec_step 12,12,7,13
+	exec_step 13,13,12,14
+	exec_step 14,14,17,15
+	exec_step 15,15,22,1
+	exec_step 16,1,5,6
+	exec_step 17,6,9,11
+	exec_step 18,11,14,0
+	exec_step 19,0,20,5
+	exec_step 20,5,5,10
+	exec_step 21,10,9,15
+	exec_step 22,15,14,4
+	exec_step 23,4,20,9
+	exec_step 24,9,5,14
+	exec_step 25,14,9,3
+	exec_step 26,3,14,8
+	exec_step 27,8,20,13
+	exec_step 28,13,5,2
+	exec_step 29,2,9,7
+	exec_step 30,7,14,12
+	exec_step 31,12,20,5
+	exec_step 32,5,4,8
+	exec_step 33,8,11,11
+	exec_step 34,11,16,14
+	exec_step 35,14,23,1
+	exec_step 36,1,4,4
+	exec_step 37,4,11,7
+	exec_step 38,7,16,10
+	exec_step 39,10,23,13
+	exec_step 40,13,4,0
+	exec_step 41,0,11,3
+	exec_step 42,3,16,6
+	exec_step 43,6,23,9
+	exec_step 44,9,4,12
+	exec_step 45,12,11,15
+	exec_step 46,15,16,2
+	exec_step 47,2,23,0
+	exec_step 48,0,6,7
+	exec_step 49,7,10,14
+	exec_step 50,14,15,5
+	exec_step 51,5,21,12
+	exec_step 52,12,6,3
+	exec_step 53,3,10,10
+	exec_step 54,10,15,1
+	exec_step 55,1,21,8
+	exec_step 56,8,6,15
+	exec_step 57,15,10,6
+	exec_step 58,6,15,13
+	exec_step 59,13,21,4
+	exec_step 60,4,6,11
+	exec_step 61,11,10,2
+	exec_step 62,2,15,9
+	exec_step 63,9,21
+.endm
+
+.macro prepare_x1
+	load_words	0,0
+	orr	VAA_0.d,VA_0.d,VA_0.d
+	orr	VBB_0.d,VB_0.d,VB_0.d
+	orr	VCC_0.d,VC_0.d,VC_0.d
+	orr	VDD_0.d,VD_0.d,VD_0.d
+.endm
+
+.macro prepare_x2
+	load_words	0,0
+	orr	VAA_0.d,VA_0.d,VA_0.d
+	orr	VAA_1.d,VA_1.d,VA_1.d
+	orr	VBB_0.d,VB_0.d,VB_0.d
+	orr	VBB_1.d,VB_1.d,VB_1.d
+	orr	VCC_0.d,VC_0.d,VC_0.d
+	orr	VCC_1.d,VC_1.d,VC_1.d
+	orr	VDD_0.d,VD_0.d,VD_0.d
+	orr	VDD_1.d,VD_1.d,VD_1.d
+.endm
+
+.macro finish_x1
+	add	VA_0.s,VA_0.s,VAA_0.s
+	add	VB_0.s,VB_0.s,VBB_0.s
+	add	VC_0.s,VC_0.s,VCC_0.s
+	add	VD_0.s,VD_0.s,VDD_0.s
+.endm
+
+.macro finish_x2
+	add	VA_0.s,VA_0.s,VAA_0.s
+	add	VA_1.s,VA_1.s,VAA_1.s
+	add	VB_0.s,VB_0.s,VBB_0.s
+	add	VB_1.s,VB_1.s,VBB_1.s
+	add	VC_0.s,VC_0.s,VCC_0.s
+	add	VC_1.s,VC_1.s,VCC_1.s
+	add	VD_0.s,VD_0.s,VDD_0.s
+	add	VD_1.s,VD_1.s,VDD_1.s
+.endm
+
+.macro md5_single	pipelines:req,sve2
+	.ifnb	\sve2
+		have_sve2=1
+		eor	VZERO.d,VZERO.d,VZERO.d
+	.else
+		have_sve2=0
+	.endif
+	num_pipelines=\pipelines
+	load_init
+
+	prepare_x\pipelines\()
+	exec_steps
+	finish_x\pipelines\()
+.endm
+
+.macro md5_sve_save_stack
+	stp	d8,d9,[sp, -48]!
+	stp	d10,d11,[sp, 16]
+	stp	d12,d13,[sp, 32]
+.endm
+
+.macro md5_sve_restore_stack
+	ldp	d10,d11,[sp, 16]
+	ldp	d12,d13,[sp, 32]
+	ldp	d8,d9,[sp],48
+.endm
+
+	.section .rodata.cst16,"aM",@progbits,16
+	.align  16
+
+MD5_CONST_KEYS:
+	.word 0xd76aa478
+	.word 0xe8c7b756
+	.word 0x242070db
+	.word 0xc1bdceee
+	.word 0xf57c0faf
+	.word 0x4787c62a
+	.word 0xa8304613
+	.word 0xfd469501
+	.word 0x698098d8
+	.word 0x8b44f7af
+	.word 0xffff5bb1
+	.word 0x895cd7be
+	.word 0x6b901122
+	.word 0xfd987193
+	.word 0xa679438e
+	.word 0x49b40821
+	.word 0xf61e2562
+	.word 0xc040b340
+	.word 0x265e5a51
+	.word 0xe9b6c7aa
+	.word 0xd62f105d
+	.word 0x02441453
+	.word 0xd8a1e681
+	.word 0xe7d3fbc8
+	.word 0x21e1cde6
+	.word 0xc33707d6
+	.word 0xf4d50d87
+	.word 0x455a14ed
+	.word 0xa9e3e905
+	.word 0xfcefa3f8
+	.word 0x676f02d9
+	.word 0x8d2a4c8a
+	.word 0xfffa3942
+	.word 0x8771f681
+	.word 0x6d9d6122
+	.word 0xfde5380c
+	.word 0xa4beea44
+	.word 0x4bdecfa9
+	.word 0xf6bb4b60
+	.word 0xbebfbc70
+	.word 0x289b7ec6
+	.word 0xeaa127fa
+	.word 0xd4ef3085
+	.word 0x04881d05
+	.word 0xd9d4d039
+	.word 0xe6db99e5
+	.word 0x1fa27cf8
+	.word 0xc4ac5665
+	.word 0xf4292244
+	.word 0x432aff97
+	.word 0xab9423a7
+	.word 0xfc93a039
+	.word 0x655b59c3
+	.word 0x8f0ccc92
+	.word 0xffeff47d
+	.word 0x85845dd1
+	.word 0x6fa87e4f
+	.word 0xfe2ce6e0
+	.word 0xa3014314
+	.word 0x4e0811a1
+	.word 0xf7537e82
+	.word 0xbd3af235
+	.word 0x2ad7d2bb
+	.word 0xeb86d391


### PR DESCRIPTION
SVE (Scalable Vector Extension), if supported by CPU, will improve
the performance of md5-mb over existing Neon implementation by up
to +230% according to test on latest V1
micro-architecture

Signed-off-by: Daniel Hu <Daniel.Hu@arm.com>