### PR TITLE
SM3 mb optimization for aarch64 by SVE

### DIFF
--- a/sm3_mb/Makefile.am
+++ b/sm3_mb/Makefile.am
@@ -42,6 +42,9 @@ lsrc_aarch64 += sm3_mb/sm3_ctx_base.c \
 	sm3_mb/aarch64/sm3_mb_sm_x2.S		\
 	sm3_mb/aarch64/sm3_mb_sm_x3.S		\
 	sm3_mb/aarch64/sm3_mb_sm_x4.S		\
+	sm3_mb/aarch64/sm3_mb_mgr_sve.c		\
+	sm3_mb/aarch64/sm3_mb_ctx_sve.c		\
+	sm3_mb/aarch64/sm3_mb_sve.S		\
 	sm3_mb/aarch64/sm3_mb_mgr_asimd_aarch64.c	\
 	sm3_mb/aarch64/sm3_mb_ctx_asimd_aarch64.c	\
 	sm3_mb/aarch64/sm3_mb_asimd_x1.S	\

--- a/sm3_mb/aarch64/sm3_mb_aarch64_dispatcher.c
+++ b/sm3_mb/aarch64/sm3_mb_aarch64_dispatcher.c
@@ -28,16 +28,24 @@
 **********************************************************************/
 #include <aarch64_multibinary.h>
 
+extern int sm3_mb_sve_max_lanes(void);
+static inline int use_sve(unsigned long auxval)
+{
+	return ((auxval & HWCAP_SVE) && (sm3_mb_sve_max_lanes() >= 8));
+}
+
 DEFINE_INTERFACE_DISPATCHER(sm3_ctx_mgr_submit)
 {
 	unsigned long auxval = getauxval(AT_HWCAP);
 	if (auxval & HWCAP_SM3)
 		return PROVIDER_INFO(sm3_ctx_mgr_submit_sm);
+
+	if (use_sve(auxval))
+		return PROVIDER_INFO(sm3_ctx_mgr_submit_sve);
+
 	if (auxval & HWCAP_ASIMD)
 		return PROVIDER_INFO(sm3_ctx_mgr_submit_asimd);
-
 	return PROVIDER_BASIC(sm3_ctx_mgr_submit);
-
 }
 
 DEFINE_INTERFACE_DISPATCHER(sm3_ctx_mgr_init)
@@ -45,11 +53,13 @@ DEFINE_INTERFACE_DISPATCHER(sm3_ctx_mgr_init)
 	unsigned long auxval = getauxval(AT_HWCAP);
 	if (auxval & HWCAP_SM3)
 		return PROVIDER_INFO(sm3_ctx_mgr_init_sm);
+
+	if (use_sve(auxval))
+		return PROVIDER_INFO(sm3_ctx_mgr_init_sve);
+
 	if (auxval & HWCAP_ASIMD)
 		return PROVIDER_INFO(sm3_ctx_mgr_init_asimd);
-
 	return PROVIDER_BASIC(sm3_ctx_mgr_init);
-
 }
 
 DEFINE_INTERFACE_DISPATCHER(sm3_ctx_mgr_flush)
@@ -57,9 +67,11 @@ DEFINE_INTERFACE_DISPATCHER(sm3_ctx_mgr_flush)
 	unsigned long auxval = getauxval(AT_HWCAP);
 	if (auxval & HWCAP_SM3)
 		return PROVIDER_INFO(sm3_ctx_mgr_flush_sm);
+
+	if (use_sve(auxval))
+		return PROVIDER_INFO(sm3_ctx_mgr_flush_sve);
+
 	if (auxval & HWCAP_ASIMD)
 		return PROVIDER_INFO(sm3_ctx_mgr_flush_asimd);
-
 	return PROVIDER_BASIC(sm3_ctx_mgr_flush);
-
 }

--- a/sm3_mb/aarch64/sm3_mb_ctx_sve.c
+++ b/sm3_mb/aarch64/sm3_mb_ctx_sve.c
@@ -1,0 +1,246 @@
+/**********************************************************************
+  Copyright(c) 2022 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdint.h>
+#include <string.h>
+#include "sm3_mb.h"
+#include "memcpy_inline.h"
+#include "endian_helper.h"
+#define SM3_LOG2_BLOCK_SIZE 6
+void sm3_mb_mgr_init_sve(SM3_MB_JOB_MGR * state);
+SM3_JOB *sm3_mb_mgr_submit_sve(SM3_MB_JOB_MGR * state, SM3_JOB * job);
+SM3_JOB *sm3_mb_mgr_flush_sve(SM3_MB_JOB_MGR * state);
+static inline void hash_init_digest(SM3_WORD_T * digest);
+static inline uint32_t hash_pad(uint8_t padblock[SM3_BLOCK_SIZE * 2], uint64_t total_len);
+static SM3_HASH_CTX *sm3_ctx_mgr_resubmit(SM3_HASH_CTX_MGR * mgr, SM3_HASH_CTX * ctx);
+
+void sm3_ctx_mgr_init_sve(SM3_HASH_CTX_MGR * mgr)
+{
+	sm3_mb_mgr_init_sve(&mgr->mgr);
+}
+
+SM3_HASH_CTX *sm3_ctx_mgr_submit_sve(SM3_HASH_CTX_MGR * mgr, SM3_HASH_CTX * ctx,
+				     const void *buffer, uint32_t len, HASH_CTX_FLAG flags)
+{
+	if (flags & (~HASH_ENTIRE)) {
+		// User should not pass anything other than FIRST, UPDATE, or LAST
+		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
+	}
+
+	if (ctx->status & HASH_CTX_STS_PROCESSING) {
+		// Cannot submit to a currently processing job.
+		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
+	}
+
+	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
+		// Cannot update a finished job.
+		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
+	}
+
+	if (flags & HASH_FIRST) {
+		// Init digest
+		hash_init_digest(ctx->job.result_digest);
+
+		// Reset byte counter
+		ctx->total_length = 0;
+
+		// Clear extra blocks
+		ctx->partial_block_buffer_length = 0;
+	}
+	// If we made it here, there were no errors during this call to submit
+	ctx->error = HASH_CTX_ERROR_NONE;
+
+	// Store buffer ptr info from user
+	ctx->incoming_buffer = buffer;
+	ctx->incoming_buffer_length = len;
+
+	// Store the user's request flags and mark this ctx as currently being processed.
+	ctx->status = (flags & HASH_LAST) ?
+	    (HASH_CTX_STS) (HASH_CTX_STS_PROCESSING | HASH_CTX_STS_LAST) :
+	    HASH_CTX_STS_PROCESSING;
+
+	// Advance byte counter
+	ctx->total_length += len;
+
+	// If there is anything currently buffered in the extra blocks, append to it until it contains a whole block.
+	// Or if the user's buffer contains less than a whole block, append as much as possible to the extra block.
+	if ((ctx->partial_block_buffer_length) | (len < SM3_BLOCK_SIZE)) {
+		// Compute how many bytes to copy from user buffer into extra block
+		uint32_t copy_len = SM3_BLOCK_SIZE - ctx->partial_block_buffer_length;
+		if (len < copy_len)
+			copy_len = len;
+
+		if (copy_len) {
+			// Copy and update relevant pointers and counters
+			memcpy_fixedlen(&ctx->partial_block_buffer
+					[ctx->partial_block_buffer_length], buffer, copy_len);
+
+			ctx->partial_block_buffer_length += copy_len;
+			ctx->incoming_buffer = (const void *)((const char *)buffer + copy_len);
+			ctx->incoming_buffer_length = len - copy_len;
+		}
+		// The extra block should never contain more than 1 block here
+		assert(ctx->partial_block_buffer_length <= SM3_BLOCK_SIZE);
+
+		// If the extra block buffer contains exactly 1 block, it can be hashed.
+		if (ctx->partial_block_buffer_length >= SM3_BLOCK_SIZE) {
+			ctx->partial_block_buffer_length = 0;
+
+			ctx->job.buffer = ctx->partial_block_buffer;
+			ctx->job.len = 1;
+
+			ctx = (SM3_HASH_CTX *) sm3_mb_mgr_submit_sve(&mgr->mgr, &ctx->job);
+		}
+	}
+
+	return sm3_ctx_mgr_resubmit(mgr, ctx);
+}
+
+SM3_HASH_CTX *sm3_ctx_mgr_flush_sve(SM3_HASH_CTX_MGR * mgr)
+{
+	SM3_HASH_CTX *ctx;
+
+	while (1) {
+		ctx = (SM3_HASH_CTX *) sm3_mb_mgr_flush_sve(&mgr->mgr);
+
+		// If flush returned 0, there are no more jobs in flight.
+		if (!ctx)
+			return NULL;
+
+		// If flush returned a job, verify that it is safe to return to the user.
+		// If it is not ready, resubmit the job to finish processing.
+		ctx = sm3_ctx_mgr_resubmit(mgr, ctx);
+
+		// If sm3_ctx_mgr_resubmit returned a job, it is ready to be returned.
+		if (ctx)
+			return ctx;
+
+		// Otherwise, all jobs currently being managed by the SM3_HASH_CTX_MGR still need processing. Loop.
+	}
+}
+
+static SM3_HASH_CTX *sm3_ctx_mgr_resubmit(SM3_HASH_CTX_MGR * mgr, SM3_HASH_CTX * ctx)
+{
+	while (ctx) {
+
+		if (ctx->status & HASH_CTX_STS_COMPLETE) {
+			ctx->status = HASH_CTX_STS_COMPLETE;	// Clear PROCESSING bit
+			return ctx;
+		}
+		// If the extra blocks are empty, begin hashing what remains in the user's buffer.
+		if (ctx->partial_block_buffer_length == 0 && ctx->incoming_buffer_length) {
+			const void *buffer = ctx->incoming_buffer;
+			uint32_t len = ctx->incoming_buffer_length;
+
+			// Only entire blocks can be hashed. Copy remainder to extra blocks buffer.
+			uint32_t copy_len = len & (SM3_BLOCK_SIZE - 1);
+
+			if (copy_len) {
+				len -= copy_len;
+				memcpy_fixedlen(ctx->partial_block_buffer,
+						((const char *)buffer + len), copy_len);
+				ctx->partial_block_buffer_length = copy_len;
+			}
+
+			ctx->incoming_buffer_length = 0;
+
+			// len should be a multiple of the block size now
+			assert((len % SM3_BLOCK_SIZE) == 0);
+
+			// Set len to the number of blocks to be hashed in the user's buffer
+			len >>= SM3_LOG2_BLOCK_SIZE;
+
+			if (len) {
+				ctx->job.buffer = (uint8_t *) buffer;
+				ctx->job.len = len;
+				ctx = (SM3_HASH_CTX *) sm3_mb_mgr_submit_sve(&mgr->mgr,
+									     &ctx->job);
+				continue;
+			}
+		}
+		// If the extra blocks are not empty, then we are either on the last block(s)
+		// or we need more user input before continuing.
+		if (ctx->status & HASH_CTX_STS_LAST) {
+			uint8_t *buf = ctx->partial_block_buffer;
+			uint32_t n_extra_blocks = hash_pad(buf, ctx->total_length);
+
+			ctx->status =
+			    (HASH_CTX_STS) (HASH_CTX_STS_PROCESSING | HASH_CTX_STS_COMPLETE);
+			ctx->job.buffer = buf;
+			ctx->job.len = (uint32_t) n_extra_blocks;
+			ctx = (SM3_HASH_CTX *) sm3_mb_mgr_submit_sve(&mgr->mgr, &ctx->job);
+			continue;
+		}
+
+		if (ctx)
+			ctx->status = HASH_CTX_STS_IDLE;
+		return ctx;
+	}
+
+	return NULL;
+}
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define cpu_to_be32(v) (((v&0xff000000)>>24) | ((v&0xff0000)>>8) | ((v&0xff00)<<8) | ((v&0xff)<<24))
+#else
+#define cpu_to_be32(v)
+#endif
+static inline void hash_init_digest(SM3_WORD_T * digest)
+{
+	static const SM3_WORD_T hash_initial_digest[SM3_DIGEST_NWORDS] =
+	    { cpu_to_be32(0x7380166f), cpu_to_be32(0x4914b2b9),
+		cpu_to_be32(0x172442d7), cpu_to_be32(0xda8a0600),
+		cpu_to_be32(0xa96f30bc), cpu_to_be32(0x163138aa),
+		cpu_to_be32(0xe38dee4d), cpu_to_be32(0xb0fb0e4e)
+	};
+	memcpy_fixedlen(digest, hash_initial_digest, sizeof(hash_initial_digest));
+}
+
+static inline uint32_t hash_pad(uint8_t padblock[SM3_BLOCK_SIZE * 2], uint64_t total_len)
+{
+	uint32_t i = (uint32_t) (total_len & (SM3_BLOCK_SIZE - 1));
+
+	memclr_fixedlen(&padblock[i], SM3_BLOCK_SIZE);
+	padblock[i] = 0x80;
+
+	// Move i to the end of either 1st or 2nd extra block depending on length
+	i += ((SM3_BLOCK_SIZE - 1) & (0 - (total_len + SM3_PADLENGTHFIELD_SIZE + 1))) + 1 +
+	    SM3_PADLENGTHFIELD_SIZE;
+
+#if SM3_PADLENGTHFIELD_SIZE == 16
+	*((uint64_t *) & padblock[i - 16]) = 0;
+#endif
+
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
+
+	return i >> SM3_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
+}

--- a/sm3_mb/aarch64/sm3_mb_mgr_sve.c
+++ b/sm3_mb/aarch64/sm3_mb_mgr_sve.c
@@ -1,0 +1,209 @@
+/**********************************************************************
+  Copyright(c) 2022 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stddef.h>
+#include <sm3_mb.h>
+#include <assert.h>
+
+#ifndef max
+#define max(a,b)            (((a) > (b)) ? (a) : (b))
+#endif
+
+#ifndef min
+#define min(a,b)            (((a) < (b)) ? (a) : (b))
+#endif
+
+extern void sm3_mb_sve(int blocks, int total_lanes, SM3_JOB **);
+extern void sm3_mb_asimd_x4(SM3_JOB *, SM3_JOB *, SM3_JOB *, SM3_JOB *, int);
+extern void sm3_mb_asimd_x1(SM3_JOB *, int);
+extern int sm3_mb_sve_max_lanes(void);
+
+#define LANE_IS_NOT_FINISHED(state,i)  	\
+	(((state->lens[i]&(~0xf))!=0) && state->ldata[i].job_in_lane!=NULL)
+#define LANE_IS_FINISHED(state,i)  	\
+	(((state->lens[i]&(~0xf))==0) && state->ldata[i].job_in_lane!=NULL)
+#define	LANE_IS_FREE(state,i)		\
+	(((state->lens[i]&(~0xf))==0) && state->ldata[i].job_in_lane==NULL)
+#define LANE_IS_INVALID(state,i)	\
+	(((state->lens[i]&(~0xf))!=0) && state->ldata[i].job_in_lane==NULL)
+void sm3_mb_mgr_init_sve(SM3_MB_JOB_MGR * state)
+{
+	unsigned int i;
+	int maxjobs = sm3_mb_sve_max_lanes();
+
+	if (maxjobs > SM3_MAX_LANES)
+		maxjobs = SM3_MAX_LANES;
+	state->unused_lanes = 0xf;
+	state->num_lanes_inuse = 0;
+
+	for (i = 0; i < maxjobs; i++) {
+		state->unused_lanes <<= 4;
+		state->unused_lanes |= maxjobs - 1 - i;
+		state->lens[i] = i;
+		state->ldata[i].job_in_lane = 0;
+	}
+
+	for (; i < SM3_MAX_LANES; i++) {
+		state->lens[i] = 0xf;
+		state->ldata[i].job_in_lane = 0;
+	}
+}
+
+static int sm3_mb_mgr_do_jobs(SM3_MB_JOB_MGR * state)
+{
+	int lane_idx, len, i, lanes, blocks;
+	SM3_JOB *job_vecs[SM3_MAX_LANES];
+	int maxjobs;
+
+	if (state->num_lanes_inuse == 0) {
+		return -1;
+	}
+
+	maxjobs = sm3_mb_sve_max_lanes();
+	if (maxjobs > SM3_MAX_LANES)
+		maxjobs = SM3_MAX_LANES;
+
+	lanes = 0;
+	len = 0;
+	for (i = 0; i < SM3_MAX_LANES && lanes < state->num_lanes_inuse; i++) {
+		if (LANE_IS_NOT_FINISHED(state, i)) {
+			if (lanes)
+				len = min(len, state->lens[i]);
+			else
+				len = state->lens[i];
+			job_vecs[lanes++] = state->ldata[i].job_in_lane;
+		}
+	}
+
+	if (lanes == 0)
+		return -1;
+	lane_idx = len & 0xf;
+	len &= ~0xf;
+	blocks = len >> 4;
+
+	if (lanes >= maxjobs - 2) {
+		sm3_mb_sve(blocks, lanes, job_vecs);
+	} else {
+		i = 0;
+		while (i + 3 < lanes) {
+			sm3_mb_asimd_x4(job_vecs[i], job_vecs[i + 1],
+					job_vecs[i + 2], job_vecs[i + 3], blocks);
+			i += 4;
+		}
+
+		while (i < lanes) {
+			sm3_mb_asimd_x1(job_vecs[i++], blocks);
+		}
+	}
+	for (i = 0; i < SM3_MAX_LANES; i++) {
+		if (LANE_IS_NOT_FINISHED(state, i)) {
+			state->lens[i] -= len;
+			state->ldata[i].job_in_lane->len -= len;
+			state->ldata[i].job_in_lane->buffer += len << 2;
+		}
+	}
+
+	return lane_idx;
+}
+
+static SM3_JOB *sm3_mb_mgr_free_lane(SM3_MB_JOB_MGR * state)
+{
+	int i;
+	SM3_JOB *ret = NULL;
+
+	for (i = 0; i < SM3_MAX_LANES; i++) {
+		if (LANE_IS_FINISHED(state, i)) {
+			state->unused_lanes <<= 4;
+			state->unused_lanes |= i;
+			state->num_lanes_inuse--;
+			ret = state->ldata[i].job_in_lane;
+			ret->status = STS_COMPLETED;
+			state->ldata[i].job_in_lane = NULL;
+			break;
+		}
+	}
+	return ret;
+}
+
+static void sm3_mb_mgr_insert_job(SM3_MB_JOB_MGR * state, SM3_JOB * job)
+{
+	int lane_idx;
+
+	//add job into lanes
+	lane_idx = state->unused_lanes & 0xf;
+	state->lens[lane_idx] = (job->len << 4) | lane_idx;
+	state->ldata[lane_idx].job_in_lane = job;
+	state->unused_lanes >>= 4;
+	state->num_lanes_inuse++;
+}
+
+SM3_JOB *sm3_mb_mgr_submit_sve(SM3_MB_JOB_MGR * state, SM3_JOB * job)
+{
+#ifndef NDEBUG
+	int lane_idx;
+#endif
+	SM3_JOB *ret;
+	int maxjobs = sm3_mb_sve_max_lanes();
+
+	if (maxjobs > SM3_MAX_LANES)
+		maxjobs = SM3_MAX_LANES;
+
+	//add job into lanes
+	sm3_mb_mgr_insert_job(state, job);
+
+	ret = sm3_mb_mgr_free_lane(state);
+	if (ret != NULL) {
+		return ret;
+	}
+	//submit will wait all lane has data
+	if (state->num_lanes_inuse < maxjobs)
+		return NULL;
+#ifndef NDEBUG
+	lane_idx = sm3_mb_mgr_do_jobs(state);
+	assert(lane_idx != -1);
+#else
+	sm3_mb_mgr_do_jobs(state);
+#endif
+
+	//~ i = lane_idx;
+	ret = sm3_mb_mgr_free_lane(state);
+	return ret;
+}
+
+SM3_JOB *sm3_mb_mgr_flush_sve(SM3_MB_JOB_MGR * state)
+{
+	SM3_JOB *ret;
+
+	ret = sm3_mb_mgr_free_lane(state);
+	if (ret) {
+		return ret;
+	}
+
+	sm3_mb_mgr_do_jobs(state);
+	return sm3_mb_mgr_free_lane(state);
+}

--- a/sm3_mb/aarch64/sm3_mb_sve.S
+++ b/sm3_mb/aarch64/sm3_mb_sve.S
@@ -1,0 +1,162 @@
+/**********************************************************************
+  Copyright(c) 2022 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+	.arch armv8.2-a+sve
+
+.macro copy_mb_16words vecs:req,dest:req
+	mov	src,\vecs
+	mov	dst,\dest
+	mov	ctr,lanes
+1:
+	ldr	tmp,[src],8
+	ldr	tmp,[tmp]
+	add	tmp,tmp,block_ctr,lsl 6
+	ld1	{TMPV0.4s,TMPV1.4s,TMPV2.4s,TMPV3.4s}, [tmp]
+	st1	{TMPV0.4s,TMPV1.4s,TMPV2.4s,TMPV3.4s}, [dst],64
+	subs	ctr,ctr,1
+	b.ne	1b
+.endm
+
+.macro load_words windex:req
+	.if	\windex == 0
+		mov	tmpw,16
+		index VOFFS.s,0,tmpw
+		copy_mb_16words	job_vec,databuf
+		mov	dataptr,databuf
+	.endif
+	ld1w	{ WORD\windex\().s}, p0/z, [dataptr, VOFFS.s, UXTW 2]
+	add	dataptr,dataptr,4
+.endm
+
+#include "sm3_sve_common.S"
+
+/* int sm3_mb_sve_max_lanes()
+ * return : max lanes of SVE vector
+ */
+	.global sm3_mb_sve_max_lanes
+	.type sm3_mb_sve_max_lanes, %function
+sm3_mb_sve_max_lanes:
+	cntw	x0
+	ret
+	.size sm3_mb_sve_max_lanes, .-sm3_mb_sve_max_lanes
+/*
+ *  void sm3_mb_sve(int blocks, int total_lanes, SM3_JOB **job_vec)
+ */
+	num_blocks	.req	w0
+	total_lanes	.req	w1
+	job_vec	.req	x2
+	lanes	.req	x4
+	src	.req	x5
+	dst	.req	x6
+	lane_offset	.req	w7
+	lane_offset_x	.req	x7
+	tmp	.req	x8
+	tmpw	.req	w8
+	block_ctr	.req	x9
+	block_ctr_w	.req	w9
+	savedsp	.req	x10
+	databuf	.req	x11
+	dataptr	.req	x12
+	efgh_buf	.req	x12
+	ctr	.req	x13
+	abcd_buf	.req	x14
+	sm3const_adr	.req	x15
+
+	.global sm3_mb_sve
+	.type sm3_mb_sve, %function
+sm3_mb_sve:
+	cbz	num_blocks,.return
+	sm3_sve_save_stack
+	mov	savedsp,sp
+	mov	lane_offset, #0
+	whilelo	p0.s,	wzr, total_lanes
+	// reserve (32 * max lanes) for abcdefgh buf
+	cntw	tmp
+	lsl	tmp, tmp, 5
+	sub	abcd_buf,sp,tmp
+	mov	tmp,63
+	bic	abcd_buf,abcd_buf,tmp
+	// reserve (64 * lanes) for data buf
+	cntp	lanes,p0,p0.s
+	lsl	tmp,lanes,6
+	sub	databuf,abcd_buf,tmp
+	mov	sp,databuf
+	adr	sm3const_adr,SM3_CONSTS
+.seg_loops:
+	mov	src,job_vec
+	mov	dst,abcd_buf
+	cntp	lanes,p0,p0.s
+	add	efgh_buf,abcd_buf,lanes,lsl 4
+	mov	ctr,lanes
+.ldr_hash:
+	ldr	tmp,[src],8
+	add	tmp,tmp,64
+	ld1	{v0.16b, v1.16b},[tmp]
+	rev32	v0.16b,v0.16b
+	rev32	v1.16b,v1.16b
+	st1	{v0.16b},[dst],16
+	st1	{v1.16b},[efgh_buf],16
+	subs	ctr,ctr,1
+	bne	.ldr_hash
+	ld4w	{VA.s,VB.s,VC.s,VD.s},p0/z,[abcd_buf]
+	add	tmp,abcd_buf,lanes,lsl 4
+	ld4w	{VE.s,VF.s,VG.s,VH.s},p0/z,[tmp]
+	mov	block_ctr,0
+	// always unpredicated SVE mode in current settings
+	pred_mode=0
+.block_loop:
+	sm3_single
+	add	block_ctr, block_ctr, 1
+	cmp	block_ctr_w,num_blocks
+	bne	.block_loop
+	st4w	{VA.s,VB.s,VC.s,VD.s},p0,[abcd_buf]
+	add	efgh_buf,abcd_buf,lanes,lsl 4
+	st4w	{VE.s,VF.s,VG.s,VH.s},p0,[efgh_buf]
+	mov	dst,job_vec
+	mov	src,abcd_buf
+	add	job_vec,job_vec,lanes,lsl 3
+	mov	ctr,lanes
+.str_hash:
+	ld1	{v0.16b},[src],16
+	ld1	{v1.16b},[efgh_buf],16
+	rev32	v0.16b,v0.16b
+	rev32	v1.16b,v1.16b
+	ldr	tmp,[dst],8
+	add	tmp,tmp,64
+	st1	{v0.16b,v1.16b},[tmp]
+	subs	ctr,ctr,1
+	bne	.str_hash
+	incw	lane_offset_x
+	whilelo	p0.s,	lane_offset, total_lanes
+	b.mi	.seg_loops
+	mov	sp,savedsp
+	sm3_sve_restore_stack
+.return:
+	ret
+	.size sm3_mb_sve, .-sm3_mb_sve

--- a/sm3_mb/aarch64/sm3_sve_common.S
+++ b/sm3_mb/aarch64/sm3_sve_common.S
@@ -1,0 +1,499 @@
+/**********************************************************************
+  Copyright(c) 2022 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+	VA	.req z0
+	VB	.req z1
+	VC	.req z2
+	VD	.req z3
+	VE	.req z4
+	VF	.req z5
+	VG	.req z6
+	VH	.req z7
+	TMPV0	.req v8
+	TMPV1	.req v9
+	TMPV2	.req v10
+	TMPV3	.req v11
+	WORD0	.req z8
+	WORD1	.req z9
+	WORD2	.req z10
+	WORD3	.req z11
+	WORD4	.req z12
+	WORD5	.req z13
+	WORD6	.req z14
+	WORD7	.req z15
+	WORD8	.req z16
+	WORD9	.req z17
+	WORD10	.req z18
+	WORD11	.req z19
+	WORD12	.req z20
+	WORD13	.req z21
+	WORD14	.req z22
+	WORD15	.req z23
+	WORD16	.req z24
+	VOFFS	.req z24	// reuse WORD16
+	SS1	.req z25
+	SS2	.req z26
+	VT	.req z26	// reuse SS2
+	TT2	.req z27
+	VT1	.req z28
+	VT2	.req z29
+	VT3	.req z30
+	VT4	.req z31
+	VZERO	.req z31
+	TT	.req z0
+
+.macro sve_op	inst:req,regd,args:vararg
+	.if	pred_mode == 1
+		\inst	\regd,p0/m,\args
+	.else
+		\inst	\regd,\args
+	.endif
+.endm
+
+.macro sve_bitop	inst:req,regd:req,regm:req
+	.if	pred_mode == 1
+		\inst	\regd\().s,p0/m,\regd\().s,\regm\().s
+	.else
+		\inst	\regd\().d,\regd\().d,\regm\().d
+	.endif
+.endm
+
+.macro rotate_left0	out:req,in:req,tmp:req,bits:req,args:vararg
+	.if	have_sve2 == 0
+		lsl	\tmp\().s,\in\().s,\bits
+	.else
+		movprfx	\out\().d,\in\().d
+		xar	\out\().s,\out\().s,VZERO.s,32-\bits
+	.endif
+
+	.ifnb	\args
+		rotate_left0	\args
+	.endif
+.endm
+
+.macro rotate_left1	out:req,in:req,tmp:req,bits:req,args:vararg
+	.if	have_sve2 == 0
+		lsr	\out\().s,\in\().s,32-\bits
+	.endif
+
+	.ifnb	\args
+		rotate_left1	\args
+	.endif
+.endm
+
+.macro rotate_left2	out:req,in:req,tmp:req,bits:req,args:vararg
+	.if	have_sve2 == 0
+		orr	\out\().d,\out\().d,\tmp\().d
+	.endif
+
+	.ifnb	\args
+		rotate_left2	\args
+	.endif
+.endm
+
+.macro rotate_left	args:vararg
+	rotate_left0	\args
+	rotate_left1	\args
+	rotate_left2	\args
+.endm
+
+.macro SVE_EOR3 rd:req,r1:req,r2:req
+	.if	have_sve2 == 0
+		sve_bitop	eor,\rd,\r1
+		sve_bitop	eor,\rd,\r2
+	.else
+		eor3	\rd\().d,\rd\().d,\r1\().d,\r2\().d
+	.endif
+.endm
+
+.macro FUNC_EOR3	ret:req,x:req,y:req,z:req
+	.if	have_sve2 == 0
+		eor	\ret\().d,\x\().d,\y\().d
+		sve_bitop	eor,\ret,\z
+	.else
+		movprfx	\ret\().d,\x\().d
+		eor3	\ret\().d,\ret\().d,\y\().d,\z\().d
+	.endif
+.endm
+
+.macro FUNC_FF	windex:req,ret:req,x:req,y:req,z:req,tmp1:req,tmp2:req
+	and	\ret\().d,\x\().d,\y\().d
+	and	\tmp1\().d,\x\().d,\z\().d
+	and	\tmp2\().d,\y\().d,\z\().d
+	sve_bitop	orr,\ret,\tmp1
+	sve_bitop	orr,\ret,\tmp2
+.endm
+
+.macro FUNC_BSL	ret:req,x:req,y:req,z:req,tmp:req
+	.if have_sve2 == 0
+		bic	\ret\().d,\z\().d,\x\().d
+		and	\tmp\().d,\x\().d,\y\().d
+		sve_bitop	orr,\ret,\tmp
+	.else
+		movprfx	\ret\().d,\x\().d
+		bsl	\ret\().d,\ret\().d,\y\().d,\z\().d
+	.endif
+.endm
+
+.altmacro
+.macro load_next_words windex
+	.if \windex < 16
+		load_words	\windex
+	.endif
+.endm
+
+.macro SM3_STEP_00_11 windex:req,w:req,w4:req
+	// SS1 = rol32(rol32(a, 12) + e + rol32(T, (j % 32)), 7)
+	ld1rw	{VT2.s},p0/z,[sm3const_adr,\windex * 4]
+	rotate_left	SS1,VA,VT1,12
+	mov	SS2.s,p0/m,SS1.s
+	sve_op	add,SS1.s,SS1.s,VE.s
+	sve_op	add,SS1.s,SS1.s,VT2.s
+	rotate_left	SS1,SS1,VT2,7
+	// d <- TT2 = GG(index, e, f, g) + h + SS1 + W[index]
+	add	VT2.s,\w\().s,VH.s
+	FUNC_EOR3	TT2,VE,VF,VG
+	// SS2 = SS1 ^ rol32(a, 12)
+	sve_bitop	eor,SS2,SS1
+	sve_op	add,TT2.s,TT2.s,VT2.s
+	// h <- TT1 = FF(index, a, b, c) + d + SS2 + WB[index]
+	FUNC_EOR3	VH,VA,VB,VC
+	eor	VT1.d,\w\().d,\w4\().d
+	sve_op	add,VH.s,VH.s,VD.s
+	sve_op	add,VH.s,VH.s,VT1.s
+	add	VD.s,TT2.s,SS1.s
+	sve_op	add,VH.s,VH.s,SS2.s
+	// d = P0(TT2)
+	rotate_left	VT1,VD,VT2,9,VT3,VD,VT4,17
+	SVE_EOR3	VD,VT1,VT3
+	// b = rol32(b, 9)
+	// f = rol32(f, 19)
+	rotate_left	VB,VB,VT3,9,VF,VF,VT4,19
+.endm
+
+.macro SM3_STEP_12_15 windex:req,w:req,w4:req,w16:req,w13:req,w9:req,w6:req,w3:req
+	// SS1 = rol32(rol32(a, 12) + e + rol32(T, (j % 32)), 7)
+	rotate_left	VT,\w3,VT1,15,\w4,\w13,VT2,7,SS1,VA,VT3,12
+	ld1rw	{VT1.s},p0/z,[sm3const_adr,\windex * 4]
+	mov	TT2.s,p0/m,SS1.s
+	sve_bitop	eor,VT,\w16
+	sve_op	add,SS1.s,SS1.s,VE.s
+	sve_bitop	eor,VT,\w9
+	sve_op	add,SS1.s,SS1.s,VT1.s
+	rotate_left	VT1,VT,VT2,15,VT3,VT,VT4,23
+	SVE_EOR3	VT,VT1,VT3
+	rotate_left	SS1,SS1,VT2,7
+	sve_bitop	eor,\w4,VT
+	// SS2 = SS1 ^ rol32(a, 12)
+	eor	SS2.d,TT2.d,SS1.d
+	sve_bitop	eor,\w4,\w6
+	// d <- TT2 = GG(index, e, f, g) + h + SS1 + W[index]
+	FUNC_EOR3	TT2,VE,VF,VG
+	add	VT1.s,\w\().s,VH.s
+	sve_op	add,TT2.s,TT2.s,VT1.s
+	// h <- TT1 = FF(index, a, b, c) + d + SS2 + WB[index]
+	FUNC_EOR3	VH,VA,VB,VC
+	eor	VT1.d,\w\().d,\w4\().d
+	sve_op	add,VH.s,VH.s,VD.s
+	// b = rol32(b, 9)
+	// f = rol32(f, 19)
+	rotate_left	VB,VB,VT3,9
+	sve_op	add,VH.s,VH.s,VT1.s
+	add	VD.s,TT2.s,SS1.s
+	sve_op	add,VH.s,VH.s,SS2.s
+	// d = P0(TT2)
+	rotate_left	VT1,VD,VT2,9,VT3,VD,VT4,17,VF,VF,TT2,19
+	SVE_EOR3	VD,VT1,VT3
+.endm
+
+.macro SM3_STEP_16_62 windex:req,w:req,w4:req,w16:req,w13:req,w9:req,w6:req,w3:req
+	// SS1 = rol32(rol32(a, 12) + e + rol32(T, (j % 32)), 7)
+	rotate_left	VT,\w3,VT1,15,\w4,\w13,VT2,7,SS1,VA,VT3,12
+	ld1rw	{VT1.s},p0/z,[sm3const_adr,\windex * 4]
+	mov	TT2.s,p0/m,SS1.s
+	sve_bitop	eor,VT,\w16
+	sve_op	add,SS1.s,SS1.s,VE.s
+	sve_bitop	eor,VT,\w9
+	sve_op	add,SS1.s,SS1.s,VT1.s
+	rotate_left	VT1,VT,VT2,15,VT3,VT,VT4,23
+	SVE_EOR3	\w4,VT,VT1
+	rotate_left	SS1,SS1,VT2,7
+	sve_bitop	eor,\w4,VT3
+	// SS2 = SS1 ^ rol32(a, 12)
+	eor	SS2.d,TT2.d,SS1.d
+	sve_bitop	eor,\w4,\w6
+	// d <- TT2 = GG(index, e, f, g) + h + SS1 + W[index]
+	sve_op	add,SS1.s,SS1.s,\w\().s
+	FUNC_BSL	TT2,VE,VF,VG,VT1
+	sve_op	add,SS1.s,SS1.s,VH.s
+	// h <- TT1 = FF(index, a, b, c) + d + SS2 + WB[index]
+	FUNC_FF	\windex,VH,VA,VB,VC,VT1,VT2
+	eor	VT1.d,\w\().d,\w4\().d
+	sve_op	add,VH.s,VH.s,VD.s
+	// b = rol32(b, 9)
+	// f = rol32(f, 19)
+	rotate_left	VB,VB,VT2,9,VF,VF,VT4,19
+	sve_op	add,VH.s,VH.s,VT1.s
+	add	VD.s,TT2.s,SS1.s
+	sve_op	add,VH.s,VH.s,SS2.s
+	// d = P0(TT2)
+	rotate_left	VT1,VD,VT2,9,VT3,VD,VT4,17
+	SVE_EOR3	VD,VT1,VT3
+.endm
+
+.macro SM3_STEP_63 windex:req,w:req,w4:req,w16:req,w13:req,w9:req,w6:req,w3:req
+	// SS1 = rol32(rol32(a, 12) + e + rol32(T, (j % 32)), 7)
+	rotate_left	VT,\w3,VT1,15,\w4,\w13,VT2,7,SS1,VA,VT3,12
+	ld1rw	{VT1.s},p0/z,[sm3const_adr,\windex * 4]
+	mov	TT2.s,p0/m,SS1.s
+	sve_bitop	eor,VT,\w16
+	sve_op	add,SS1.s,SS1.s,VE.s
+	sve_bitop	eor,VT,\w9
+	sve_op	add,SS1.s,SS1.s,VT1.s
+	rotate_left	VT1,VT,VT2,15,VT3,VT,VT4,23
+	SVE_EOR3	VT,VT1,VT3
+	rotate_left	SS1,SS1,VT2,7
+	sve_bitop	eor,\w4,VT
+	// SS2 = SS1 ^ rol32(a, 12)
+	eor	SS2.d,TT2.d,SS1.d
+	sve_bitop	eor,\w4,\w6
+	// d <- TT2 = GG(index, e, f, g) + h + SS1 + W[index]
+	FUNC_BSL	TT2,VE,VF,VG,VT1
+	add	VT1.s,\w\().s,VH.s
+	.if \windex == 63
+		ld1w    {WORD0.s},p0/z,[abcd_buf, 0, MUL VL]
+		ld1w    {WORD1.s},p0/z,[abcd_buf, 1, MUL VL]
+		ld1w    {WORD2.s},p0/z,[abcd_buf, 2, MUL VL]
+		ld1w    {WORD3.s},p0/z,[abcd_buf, 3, MUL VL]
+		ld1w    {WORD4.s},p0/z,[abcd_buf, 4, MUL VL]
+		ld1w    {WORD5.s},p0/z,[abcd_buf, 5, MUL VL]
+		ld1w    {WORD6.s},p0/z,[abcd_buf, 6, MUL VL]
+		ld1w    {WORD7.s},p0/z,[abcd_buf, 7, MUL VL]
+	.endif
+	sve_op	add,TT2.s,TT2.s,VT1.s
+	// h <- TT1 = FF(index, a, b, c) + d + SS2 + WB[index]
+	FUNC_FF	\windex,VH,VA,VB,VC,VT1,VT2
+	eor	VT1.d,\w\().d,\w4\().d
+	sve_op	add,VH.s,VH.s,VD.s
+	// b = rol32(b, 9)
+	// f = rol32(f, 19)
+	rotate_left	VB,VB,VT2,9,VF,VF,VT4,19
+	sve_op	add,VH.s,VH.s,VT1.s
+	add	VD.s,TT2.s,SS1.s
+	sve_bitop	eor,VA,WORD1
+	sve_bitop	eor,VB,WORD2
+	sve_bitop	eor,VC,WORD3
+	// d = P0(TT2)
+	rotate_left	VT1,VD,VT2,9,VT3,VD,VT4,17
+	sve_bitop	eor,VF,WORD6
+	SVE_EOR3	VD,VT1,VT3
+	sve_bitop	eor,VG,WORD7
+	sve_bitop	eor,VD,WORD4
+	sve_op	add,VH.s,VH.s,SS2.s
+	sve_bitop	eor,VE,WORD5
+	sve_bitop	eor,VH,WORD0
+.endm
+
+.macro SWAP_STATES
+	.unreq TT
+	TT .req VH
+	.unreq VH
+	VH .req VG
+	.unreq VG
+	VG .req VF
+	.unreq VF
+	VF .req VE
+	.unreq VE
+	VE .req VD
+	.unreq VD
+	VD .req VC
+	.unreq VC
+	VC .req VB
+	.unreq VB
+	VB .req VA
+	.unreq VA
+	VA .req TT
+.endm
+
+.altmacro
+.macro SM3_STEP_WRAPPER windex:req,idx:req,idx4:req,idx16,idx13,idx9,idx6,idx3
+	.if \windex <= 11
+		revb	WORD\idx4\().s, p0/m, WORD\idx4\().s
+		next=\idx4+1
+		load_next_words %next
+		SM3_STEP_00_11	\windex,WORD\idx\(),WORD\idx4\()
+	.else
+		.if \windex < 16
+			SM3_STEP_12_15	\windex,WORD\idx\(),WORD\idx4\(),WORD\idx16\(),WORD\idx13\(),WORD\idx9\(),WORD\idx6\(),WORD\idx3\()
+		.else
+			.if \windex == 63
+				SM3_STEP_63	\windex,WORD\idx\(),WORD\idx4\(),WORD\idx16\(),WORD\idx13\(),WORD\idx9\(),WORD\idx6\(),WORD\idx3\()
+			.else
+				SM3_STEP_16_62	\windex,WORD\idx\(),WORD\idx4\(),WORD\idx16\(),WORD\idx13\(),WORD\idx9\(),WORD\idx6\(),WORD\idx3\()
+			.endif
+		.endif
+	.endif
+.endm
+
+.macro exec_step windex:req
+	.if \windex <= 11
+		idx4=\windex+4
+		SM3_STEP_WRAPPER	\windex,\windex,%idx4
+	.else
+		idxp4=\windex + 4
+		idx4=idxp4 % 17
+		idx16=(idxp4 - 16) % 17
+		idx13=(idxp4 - 13) % 17
+		idx9=(idxp4 - 9) % 17
+		idx6=(idxp4 - 6) % 17
+		idx3=(idxp4 - 3) % 17
+		idx=\windex % 17
+		SM3_STEP_WRAPPER	\windex,%idx,%idx4,%idx16,%idx13,%idx9,%idx6,%idx3
+	.endif
+	SWAP_STATES
+.endm
+
+.macro sm3_exec
+	current_step=0
+	.rept	64
+		exec_step	%current_step
+		current_step=current_step+1
+	.endr
+.endm
+
+.macro sm3_single	sve2:vararg
+	.ifnb	\sve2
+		have_sve2 = 1
+	.else
+		have_sve2=0
+	.endif
+	st1w    {VA.s},p0,[abcd_buf, 0, MUL VL]
+	st1w    {VB.s},p0,[abcd_buf, 1, MUL VL]
+	st1w    {VC.s},p0,[abcd_buf, 2, MUL VL]
+	st1w    {VD.s},p0,[abcd_buf, 3, MUL VL]
+	st1w    {VE.s},p0,[abcd_buf, 4, MUL VL]
+	st1w    {VF.s},p0,[abcd_buf, 5, MUL VL]
+	st1w    {VG.s},p0,[abcd_buf, 6, MUL VL]
+	st1w    {VH.s},p0,[abcd_buf, 7, MUL VL]
+	load_words 0
+	load_words 1
+	load_words 2
+	load_words 3
+	load_words 4
+	revb	WORD0.s, p0/m, WORD0.s
+	revb	WORD1.s, p0/m, WORD1.s
+	revb	WORD2.s, p0/m, WORD2.s
+	revb	WORD3.s, p0/m, WORD3.s
+	.if     have_sve2 == 1
+		mov	VZERO.s,p0/m,#0
+	.endif
+	sm3_exec
+.endm
+
+.macro sm3_sve_save_stack
+	stp	d8,d9,[sp, -64]!
+	stp	d10,d11,[sp, 16]
+	stp	d12,d13,[sp, 32]
+	stp	d14,d15,[sp, 48]
+.endm
+
+.macro sm3_sve_restore_stack
+	ldp	d10,d11,[sp, 16]
+	ldp	d12,d13,[sp, 32]
+	ldp	d14,d15,[sp, 48]
+	ldp	d8,d9,[sp],64
+.endm
+
+	.section .rodata.cst16,"aM",@progbits,16
+	.align  16
+SM3_CONSTS:
+	.word 0x79CC4519
+	.word 0xF3988A32
+	.word 0xE7311465
+	.word 0xCE6228CB
+	.word 0x9CC45197
+	.word 0x3988A32F
+	.word 0x7311465E
+	.word 0xE6228CBC
+	.word 0xCC451979
+	.word 0x988A32F3
+	.word 0x311465E7
+	.word 0x6228CBCE
+	.word 0xC451979C
+	.word 0x88A32F39
+	.word 0x11465E73
+	.word 0x228CBCE6
+	.word 0x9D8A7A87
+	.word 0x3B14F50F
+	.word 0x7629EA1E
+	.word 0xEC53D43C
+	.word 0xD8A7A879
+	.word 0xB14F50F3
+	.word 0x629EA1E7
+	.word 0xC53D43CE
+	.word 0x8A7A879D
+	.word 0x14F50F3B
+	.word 0x29EA1E76
+	.word 0x53D43CEC
+	.word 0xA7A879D8
+	.word 0x4F50F3B1
+	.word 0x9EA1E762
+	.word 0x3D43CEC5
+	.word 0x7A879D8A
+	.word 0xF50F3B14
+	.word 0xEA1E7629
+	.word 0xD43CEC53
+	.word 0xA879D8A7
+	.word 0x50F3B14F
+	.word 0xA1E7629E
+	.word 0x43CEC53D
+	.word 0x879D8A7A
+	.word 0x0F3B14F5
+	.word 0x1E7629EA
+	.word 0x3CEC53D4
+	.word 0x79D8A7A8
+	.word 0xF3B14F50
+	.word 0xE7629EA1
+	.word 0xCEC53D43
+	.word 0x9D8A7A87
+	.word 0x3B14F50F
+	.word 0x7629EA1E
+	.word 0xEC53D43C
+	.word 0xD8A7A879
+	.word 0xB14F50F3
+	.word 0x629EA1E7
+	.word 0xC53D43CE
+	.word 0x8A7A879D
+	.word 0x14F50F3B
+	.word 0x29EA1E76
+	.word 0x53D43CEC
+	.word 0xA7A879D8
+	.word 0x4F50F3B1
+	.word 0x9EA1E762
+	.word 0x3D43CEC5
+


### PR DESCRIPTION
This patch optimize the sm3-mb algorithm using the SVE feature
of aarch64. SVE is optional feature for ARM v8

Tested on modern micro-architecture, it shows an 39% uplift in
performance over neon

Signed-off-by: Daniel Hu <Daniel.Hu@arm.com>