### PR TITLE
optimization for md5_mb for aarch64 by SVE2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ x86_64:
 * Optional: Building with autotools requires autoconf/automake packages.
 
 aarch64:
-* Assembler: gas v2.24 or later.
+* Assembler: gas v2.34 or later.
 * Compiler: gcc v8 or later.
+* For gas v2.24~v2.34, sve2 instructions are not supported. To workaround it, sve2 optimization should be disabled by
+    * ./configure --disable-sve2
+    * make -f Makefile.unx DEFINES+=-DNO_SVE2=1
 
 ### Autotools
 To build and install the library with autotools it is usually sufficient to run:

--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,28 @@ AC_ARG_ENABLE([debug],
 AS_IF([test "x$enable_debug" = "xyes"], [
         AC_DEFINE(ENABLE_DEBUG, [1], [Debug messages.])
 ])
+
+if test x"$CPU" = x"aarch64"; then
+   AC_ARG_ENABLE([sve2],
+        AS_HELP_STRING([--disable-sve2], [disable usage of SVE2]),
+        , enable_sve2=yes)
+   if test "$enable_sve2" = "yes"; then
+      AC_MSG_CHECKING([whether compiler supports sve2])
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
+                                         [asm(".arch armv8.2-a+sve2");])],
+                        [cc_support_sve2=yes],
+                        [cc_support_sve2=no])
+      if test x"$cc_support_sve2" = xyes ; then
+         AC_MSG_RESULT([yes])
+      else
+         AC_MSG_RESULT([no])
+         AC_MSG_ERROR([upgrade your compiler to support SVE2, or run \"./configure --disable-sve2\"])
+      fi
+   else
+	 AC_DEFINE(NO_SVE2, 1, [Define to 1 if the compiler does not supports SVE2.])
+   fi
+fi
+
 # If this build is for x86, look for yasm and nasm
 if test x"$is_x86" = x"yes"; then
 AC_MSG_CHECKING([whether Intel CET is enabled])

--- a/md5_mb/Makefile.am
+++ b/md5_mb/Makefile.am
@@ -62,6 +62,8 @@ lsrc_aarch64 += md5_mb/md5_ctx_base.c \
 		md5_mb/aarch64/md5_mb_asimd_x1.S  \
 		md5_mb/aarch64/md5_ctx_aarch64_sve.c  \
 		md5_mb/aarch64/md5_mb_mgr_aarch64_sve.c  \
+		md5_mb/aarch64/md5_ctx_aarch64_sve2.c  \
+		md5_mb/aarch64/md5_mb_mgr_aarch64_sve2.c  \
 		md5_mb/aarch64/md5_mb_sve.S  \
 		md5_mb/aarch64/md5_mb_multibinary.S
 

--- a/md5_mb/aarch64/md5_ctx_aarch64_sve2.c
+++ b/md5_mb/aarch64/md5_ctx_aarch64_sve2.c
@@ -1,0 +1,229 @@
+/**********************************************************************
+  Copyright(c) 2022 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stdlib.h>
+#include "md5_mb.h"
+#include "memcpy_inline.h"
+void md5_mb_mgr_init_sve2(MD5_MB_JOB_MGR * state);
+MD5_JOB *md5_mb_mgr_submit_sve2(MD5_MB_JOB_MGR * state, MD5_JOB * job);
+MD5_JOB *md5_mb_mgr_flush_sve2(MD5_MB_JOB_MGR * state);
+
+static inline void hash_init_digest(MD5_WORD_T * digest);
+static inline uint32_t hash_pad(uint8_t padblock[MD5_BLOCK_SIZE * 2], uint64_t total_len);
+static MD5_HASH_CTX *md5_ctx_mgr_resubmit(MD5_HASH_CTX_MGR * mgr, MD5_HASH_CTX * ctx);
+
+void md5_ctx_mgr_init_sve2(MD5_HASH_CTX_MGR * mgr)
+{
+	md5_mb_mgr_init_sve2(&mgr->mgr);
+}
+
+MD5_HASH_CTX *md5_ctx_mgr_submit_sve2(MD5_HASH_CTX_MGR * mgr, MD5_HASH_CTX * ctx,
+				      const void *buffer, uint32_t len, HASH_CTX_FLAG flags)
+{
+	if (flags & (~HASH_ENTIRE)) {
+		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
+	}
+
+	if (ctx->status & HASH_CTX_STS_PROCESSING) {
+		// Cannot submit to a currently processing job.
+		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
+	}
+
+	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
+		// Cannot update a finished job.
+		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
+	}
+
+	if (flags & HASH_FIRST) {
+		// Init digest
+		hash_init_digest(ctx->job.result_digest);
+
+		// Reset byte counter
+		ctx->total_length = 0;
+
+		// Clear extra blocks
+		ctx->partial_block_buffer_length = 0;
+	}
+	// If we made it here, there were no errors during this call to submit
+	ctx->error = HASH_CTX_ERROR_NONE;
+
+	// Store buffer ptr info from user
+	ctx->incoming_buffer = buffer;
+	ctx->incoming_buffer_length = len;
+
+	// Store the user's request flags and mark this ctx as currently being processed.
+	ctx->status = (flags & HASH_LAST) ?
+	    (HASH_CTX_STS) (HASH_CTX_STS_PROCESSING | HASH_CTX_STS_LAST) :
+	    HASH_CTX_STS_PROCESSING;
+
+	// Advance byte counter
+	ctx->total_length += len;
+
+	// If there is anything currently buffered in the extra blocks, append to it until it contains a whole block.
+	// Or if the user's buffer contains less than a whole block, append as much as possible to the extra block.
+	if ((ctx->partial_block_buffer_length) | (len < MD5_BLOCK_SIZE)) {
+		// Compute how many bytes to copy from user buffer into extra block
+		uint32_t copy_len = MD5_BLOCK_SIZE - ctx->partial_block_buffer_length;
+		if (len < copy_len)
+			copy_len = len;
+
+		if (copy_len) {
+			// Copy and update relevant pointers and counters
+			memcpy_varlen(&ctx->partial_block_buffer
+				      [ctx->partial_block_buffer_length], buffer, copy_len);
+
+			ctx->partial_block_buffer_length += copy_len;
+			ctx->incoming_buffer = (const void *)((const char *)buffer + copy_len);
+			ctx->incoming_buffer_length = len - copy_len;
+		}
+		// The extra block should never contain more than 1 block here
+		assert(ctx->partial_block_buffer_length <= MD5_BLOCK_SIZE);
+
+		// If the extra block buffer contains exactly 1 block, it can be hashed.
+		if (ctx->partial_block_buffer_length >= MD5_BLOCK_SIZE) {
+			ctx->partial_block_buffer_length = 0;
+
+			ctx->job.buffer = ctx->partial_block_buffer;
+			ctx->job.len = 1;
+			ctx = (MD5_HASH_CTX *) md5_mb_mgr_submit_sve2(&mgr->mgr, &ctx->job);
+		}
+	}
+
+	return md5_ctx_mgr_resubmit(mgr, ctx);
+}
+
+MD5_HASH_CTX *md5_ctx_mgr_flush_sve2(MD5_HASH_CTX_MGR * mgr)
+{
+	MD5_HASH_CTX *ctx;
+
+	while (1) {
+		ctx = (MD5_HASH_CTX *) md5_mb_mgr_flush_sve2(&mgr->mgr);
+
+		// If flush returned 0, there are no more jobs in flight.
+		if (!ctx)
+			return NULL;
+
+		// If flush returned a job, verify that it is safe to return to the user.
+		// If it is not ready, resubmit the job to finish processing.
+		ctx = md5_ctx_mgr_resubmit(mgr, ctx);
+
+		// If md5_ctx_mgr_resubmit returned a job, it is ready to be returned.
+		if (ctx)
+			return ctx;
+
+		// Otherwise, all jobs currently being managed by the HASH_CTX_MGR still need processing. Loop.
+	}
+}
+
+static MD5_HASH_CTX *md5_ctx_mgr_resubmit(MD5_HASH_CTX_MGR * mgr, MD5_HASH_CTX * ctx)
+{
+	while (ctx) {
+
+		if (ctx->status & HASH_CTX_STS_COMPLETE) {
+			ctx->status = HASH_CTX_STS_COMPLETE;	// Clear PROCESSING bit
+			return ctx;
+		}
+		// If the extra blocks are empty, begin hashing what remains in the user's buffer.
+		if (ctx->partial_block_buffer_length == 0 && ctx->incoming_buffer_length) {
+			const void *buffer = ctx->incoming_buffer;
+			uint32_t len = ctx->incoming_buffer_length;
+
+			// Only entire blocks can be hashed. Copy remainder to extra blocks buffer.
+			uint32_t copy_len = len & (MD5_BLOCK_SIZE - 1);
+
+			if (copy_len) {
+				len -= copy_len;
+				memcpy_varlen(ctx->partial_block_buffer,
+					      ((const char *)buffer + len), copy_len);
+				ctx->partial_block_buffer_length = copy_len;
+			}
+
+			ctx->incoming_buffer_length = 0;
+
+			// len should be a multiple of the block size now
+			assert((len % MD5_BLOCK_SIZE) == 0);
+
+			// Set len to the number of blocks to be hashed in the user's buffer
+			len >>= MD5_LOG2_BLOCK_SIZE;
+
+			if (len) {
+				ctx->job.buffer = (uint8_t *) buffer;
+				ctx->job.len = len;
+				ctx = (MD5_HASH_CTX *) md5_mb_mgr_submit_sve2(&mgr->mgr,
+									      &ctx->job);
+				continue;
+			}
+		}
+		// If the extra blocks are not empty, then we are either on the last block(s)
+		// or we need more user input before continuing.
+		if (ctx->status & HASH_CTX_STS_LAST) {
+
+			uint8_t *buf = ctx->partial_block_buffer;
+			uint32_t n_extra_blocks = hash_pad(buf, ctx->total_length);
+
+			ctx->status =
+			    (HASH_CTX_STS) (HASH_CTX_STS_PROCESSING | HASH_CTX_STS_COMPLETE);
+
+			ctx->job.buffer = buf;
+			ctx->job.len = n_extra_blocks;
+			ctx = (MD5_HASH_CTX *) md5_mb_mgr_submit_sve2(&mgr->mgr, &ctx->job);
+			continue;
+		}
+
+		if (ctx)
+			ctx->status = HASH_CTX_STS_IDLE;
+		return ctx;
+	}
+
+	return NULL;
+}
+
+static inline void hash_init_digest(MD5_WORD_T * digest)
+{
+	static const MD5_WORD_T hash_initial_digest[MD5_DIGEST_NWORDS] =
+	    { MD5_INITIAL_DIGEST };
+	memcpy_fixedlen(digest, hash_initial_digest, sizeof(hash_initial_digest));
+}
+
+static inline uint32_t hash_pad(uint8_t padblock[MD5_BLOCK_SIZE * 2], uint64_t total_len)
+{
+	uint32_t i = (uint32_t) (total_len & (MD5_BLOCK_SIZE - 1));
+
+	memclr_fixedlen(&padblock[i], MD5_BLOCK_SIZE);
+	padblock[i] = 0x80;
+
+	i += ((MD5_BLOCK_SIZE - 1) & (0 - (total_len + MD5_PADLENGTHFIELD_SIZE + 1))) + 1 +
+	    MD5_PADLENGTHFIELD_SIZE;
+
+	*((uint64_t *) & padblock[i - 8]) = ((uint64_t) total_len << 3);
+
+	return i >> MD5_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
+}

--- a/md5_mb/aarch64/md5_mb_mgr_aarch64_sve2.c
+++ b/md5_mb/aarch64/md5_mb_mgr_aarch64_sve2.c
@@ -34,7 +34,7 @@
 #define min(a,b)            (((a) < (b)) ? (a) : (b))
 #endif
 
-extern void md5_mb_sve(int blocks, int total_lanes, MD5_JOB **);
+extern void md5_mb_sve2(int blocks, int total_lanes, MD5_JOB **);
 extern void md5_mb_asimd_x4(MD5_JOB *, MD5_JOB *, MD5_JOB *, MD5_JOB *, int);
 extern void md5_mb_asimd_x1(MD5_JOB *, int);
 extern int md5_mb_sve_max_lanes(void);
@@ -47,7 +47,7 @@ extern int md5_mb_sve_max_lanes(void);
 	(((state->lens[i]&(~0xff))==0) && state->ldata[i].job_in_lane==NULL)
 #define LANE_IS_INVALID(state,i)	\
 	(((state->lens[i]&(~0xff))!=0) && state->ldata[i].job_in_lane==NULL)
-void md5_mb_mgr_init_sve(MD5_MB_JOB_MGR * state)
+void md5_mb_mgr_init_sve2(MD5_MB_JOB_MGR * state)
 {
 	unsigned int j;
 	state->unused_lanes[0] = 0x0706050403020100;
@@ -99,7 +99,7 @@ static int md5_mb_mgr_do_jobs(MD5_MB_JOB_MGR * state)
 	// lanes is less than single vector capacity minus 2
 	// Things might change for future micro-architecture
 	if (lanes >= 4 && lanes >= maxjobs / 2 - 2) {
-		md5_mb_sve(blocks, lanes, job_vecs);
+		md5_mb_sve2(blocks, lanes, job_vecs);
 	} else {
 		i = 0;
 		while (i + 3 < lanes) {
@@ -167,7 +167,7 @@ static void md5_mb_mgr_insert_job(MD5_MB_JOB_MGR * state, MD5_JOB * job)
 	state->num_lanes_inuse++;
 }
 
-MD5_JOB *md5_mb_mgr_submit_sve(MD5_MB_JOB_MGR * state, MD5_JOB * job)
+MD5_JOB *md5_mb_mgr_submit_sve2(MD5_MB_JOB_MGR * state, MD5_JOB * job)
 {
 #ifndef NDEBUG
 	int lane_idx;
@@ -199,7 +199,7 @@ MD5_JOB *md5_mb_mgr_submit_sve(MD5_MB_JOB_MGR * state, MD5_JOB * job)
 	return ret;
 }
 
-MD5_JOB *md5_mb_mgr_flush_sve(MD5_MB_JOB_MGR * state)
+MD5_JOB *md5_mb_mgr_flush_sve2(MD5_MB_JOB_MGR * state)
 {
 	MD5_JOB *ret;
 

--- a/md5_mb/aarch64/md5_mb_sve.S
+++ b/md5_mb/aarch64/md5_mb_sve.S
@@ -27,7 +27,12 @@
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **********************************************************************/
 
+#if defined(NO_SVE2)
 	.arch armv8.2-a+sve
+#else
+	.arch armv8.2-a+sve2
+#endif
+
 
 // copying data from sparse memory unto continous stack space
 // in oroder to gather-load into SVE registers
@@ -73,7 +78,7 @@ md5_mb_sve_max_lanes:
 	.size md5_mb_sve_max_lanes, .-md5_mb_sve_max_lanes
 
 /*
- *  void md5_mb_sve(int blocks, int total_lanes, MD5_JOB **job_vec)
+ *  void md5_mb_sve/sv2(int blocks, int total_lanes, MD5_JOB **job_vec)
  */
 	num_blocks	.req	w0
 	total_lanes	.req	w1
@@ -92,10 +97,8 @@ md5_mb_sve_max_lanes:
 	abcd_buf	.req	x14
 	md5key_adr	.req	x15
 
-	.global md5_mb_sve
-	.type md5_mb_sve, %function
-md5_mb_sve:
-	cbz	num_blocks,.return
+.macro IMPLEMENT_MD5_MB sve2_flag:req
+	cbz	num_blocks,.return\sve2_flag\()
 	md5_sve_save_stack
 	mov	savedsp,sp
 	// reserve (16 * lanes) for abcd buf
@@ -110,49 +113,67 @@ md5_mb_sve:
 	mov	src,job_vec
 	mov	dst,abcd_buf
 	mov	counter,total_lanes
-.ldr_hash:
+.ldr_hash\sve2_flag\():
 	ldr	tmp,[src],8
 	add	tmp,tmp,64
 	ld1	{v0.16b},[tmp]
 	st1	{v0.16b},[dst],16
 	subs	counter,counter,1
-	bne	.ldr_hash
+	bne	.ldr_hash\sve2_flag\()
 	ld4w	{VA_0.s,VB_0.s,VC_0.s,VD_0.s},p0/z,[abcd_buf]
 	mov	block_ctr,0
 	cntp	veclen,p0,p0.s
 	cmp	veclen_w,total_lanes
-	b.eq	.loop_1x
+	b.eq	.loop_1x\sve2_flag\()
 	whilelo	p1.s,veclen_w,total_lanes
 	add	tmp,abcd_buf,veclen,lsl #4
 	ld4w	{VA_1.s,VB_1.s,VC_1.s,VD_1.s},p1/z,[tmp]
-	b	.loop_2x
-.loop_1x:
-	md5_single	1
+	b	.loop_2x\sve2_flag\()
+.loop_1x\sve2_flag\():
+	md5_single	1,\sve2_flag
 	add	block_ctr, block_ctr, 1
 	cmp	block_ctr_w,num_blocks
-	bne	.loop_1x
+	bne	.loop_1x\sve2_flag\()
 	st4w	{VA_0.s,VB_0.s,VC_0.s,VD_0.s},p0,[abcd_buf]
 	b	1f
-.loop_2x:
-	md5_single	2
+.loop_2x\sve2_flag\():
+	md5_single	2,\sve2_flag
 	add	block_ctr, block_ctr, 1
 	cmp	block_ctr_w,num_blocks
-	bne	.loop_2x
+	bne	.loop_2x\sve2_flag\()
 	st4w	{VA_0.s,VB_0.s,VC_0.s,VD_0.s},p0,[abcd_buf]
 	add	tmp,abcd_buf,veclen,lsl #4
 	st4w	{VA_1.s,VB_1.s,VC_1.s,VD_1.s},p1,[tmp]
 1:
 	mov	dst,job_vec
 	mov	src,abcd_buf
-.str_hash:
+.str_hash\sve2_flag\():
 	ld1	{v0.16b},[src],16
 	ldr	tmp,[dst],8
 	add	tmp,tmp,64
 	st1	{v0.16b},[tmp]
 	subs	total_lanes,total_lanes,1
-	bne	.str_hash
+	bne	.str_hash\sve2_flag\()
 	mov	sp,savedsp
 	md5_sve_restore_stack
-.return:
+.return\sve2_flag\():
 	ret
+.endm
+
+	.global md5_mb_sve
+	.type md5_mb_sve, %function
+md5_mb_sve:
+.sve_entry:
+	IMPLEMENT_MD5_MB 0
 	.size md5_mb_sve, .-md5_mb_sve
+
+	.global md5_mb_sve2
+	.type md5_mb_sve2, %function
+md5_mb_sve2:
+#if	!defined(NO_SVE2)
+	IMPLEMENT_MD5_MB 1
+#else
+#warning "SVE2 has been bypassed in the build"
+	b	.sve_entry
+#endif
+	.size md5_mb_sve2, .-md5_mb_sve2

--- a/md5_mb/aarch64/md5_sve_common.S
+++ b/md5_mb/aarch64/md5_sve_common.S
@@ -56,6 +56,7 @@
 	VBB_1	.req z31
 	VCC_1	.req z8
 	VDD_1	.req z9
+	VZERO	.req z10
 	TT	.req z0
 
 .macro rotate_left_x1	out:req,in:req,tmp:req,bits
@@ -67,14 +68,13 @@
 			lsr	\out\().s,\in\().s,32-\bits
 			orr	\out\().d,\out\().d,\tmp\().d
 		.else
-			movprfx	\out\().d,\in\().d
+			movprfx	\out,\in
 			xar	\out\().s,\out\().s,VZERO.s,32-\bits
 		.endif
 	.endif
 .endm
 
 .macro rotate_left_x2	out:req,in:req,tmp:req,bits,out1:req,in1:req,tmp1:req,bits1
-
 	.if \bits == 16
 		revh	\out\().s,p0/m,\in\().s
 		revh	\out1\().s,p0/m,\in1\().s
@@ -87,9 +87,9 @@
 			orr	\out\().d,\out\().d,\tmp\().d
 			orr	\out1\().d,\out1\().d,\tmp1\().d
 		.else
-			movprfx	\out\().d,\in\().d
+			movprfx	\out,\in
 			xar	\out\().s,\out\().s,VZERO.s,32-\bits
-			movprfx	\out1\().d,\in1\().d
+			movprfx	\out1,\in1
 			xar	\out1\().s,\out1\().s,VZERO.s,32-\bits1
 		.endif
 	.endif
@@ -101,8 +101,8 @@
 		and	\tmp\().d,\x\().d,\y\().d
 		orr	\ret\().d,\ret\().d,\tmp\().d
 	.else
-		movprfx	\ret\().d,\x\().d
-		bsl	\ret\().d,\ret\().d,\y\().d,\z\().d
+		movprfx	\ret,\y
+		bsl	\ret\().d,\ret\().d,\z\().d,\x\().d
 	.endif
 .endm
 
@@ -115,10 +115,10 @@
 		orr	\ret\().d,\ret\().d,\tmp\().d
 		orr	\ret1\().d,\ret1\().d,\tmp1\().d
 	.else
-		movprfx	\ret\().d,\x\().d
-		bsl	\ret\().d,\ret\().d,\y\().d,\z\().d
-		movprfx	\ret1\().d,\x1\().d
-		bsl	\ret1\().d,\ret1\().d,\y1\().d,\z1\().d
+		movprfx	\ret,\y
+		bsl	\ret\().d,\ret\().d,\z\().d,\x\().d
+		movprfx	\ret1,\y1
+		bsl	\ret1\().d,\ret1\().d,\z1\().d,\x1\().d
 	.endif
 .endm
 
@@ -149,7 +149,7 @@
 		eor	VF_0.d,VB_0.d,VC_0.d
 		eor	VF_0.d,VF_0.d,VD_0.d
 	.else
-		movprfx	VF_0.d,VB_0.d
+		movprfx	VF_0,VB_0
 		eor3	VF_0.d,VF_0.d,VC_0.d,VD_0.d
 	.endif
 .endm
@@ -161,9 +161,9 @@
 		eor	VF_0.d,VF_0.d,VD_0.d
 		eor	VF_1.d,VF_1.d,VD_1.d
 	.else
-		movprfx	VF_0.d,VB_0.d
+		movprfx	VF_0,VB_0
 		eor3	VF_0.d,VF_0.d,VC_0.d,VD_0.d
-		movprfx	VF_1.d,VB_1.d
+		movprfx	VF_1,VB_1
 		eor3	VF_1.d,VF_1.d,VC_1.d,VD_1.d
 	.endif
 .endm
@@ -376,10 +376,10 @@
 	add	VD_1.s,VD_1.s,VDD_1.s
 .endm
 
-.macro md5_single	pipelines:req,sve2
-	.ifnb	\sve2
+.macro md5_single	pipelines:req,sve2_flag:req
+	.if	\sve2_flag == 1
 		have_sve2=1
-		eor	VZERO.d,VZERO.d,VZERO.d
+		dup	VZERO.s,#0
 	.else
 		have_sve2=0
 	.endif
@@ -392,15 +392,13 @@
 .endm
 
 .macro md5_sve_save_stack
-	stp	d8,d9,[sp, -48]!
+	stp	d8,d9,[sp, -32]!
 	stp	d10,d11,[sp, 16]
-	stp	d12,d13,[sp, 32]
 .endm
 
 .macro md5_sve_restore_stack
 	ldp	d10,d11,[sp, 16]
-	ldp	d12,d13,[sp, 32]
-	ldp	d8,d9,[sp],48
+	ldp	d8,d9,[sp],32
 .endm
 
 	.section .rodata.cst16,"aM",@progbits,16


### PR DESCRIPTION
SVE2-128 shows about 5% uplift over SVE-128, which
is about 70% above Neon.

Change-Id: I200c2056734d6cb7725b82e5c52c432c20efa053
Signed-off-by: Daniel Hu <Daniel.Hu@arm.com>