### PR TITLE
sm3_mb optimization by SVE2 for aarch64

### DIFF
--- a/sm3_mb/Makefile.am
+++ b/sm3_mb/Makefile.am
@@ -44,6 +44,8 @@ lsrc_aarch64 += sm3_mb/sm3_ctx_base.c \
 	sm3_mb/aarch64/sm3_mb_sm_x4.S		\
 	sm3_mb/aarch64/sm3_mb_mgr_sve.c		\
 	sm3_mb/aarch64/sm3_mb_ctx_sve.c		\
+	sm3_mb/aarch64/sm3_mb_mgr_sve2.c	\
+	sm3_mb/aarch64/sm3_mb_ctx_sve2.c	\
 	sm3_mb/aarch64/sm3_mb_sve.S		\
 	sm3_mb/aarch64/sm3_mb_mgr_asimd_aarch64.c	\
 	sm3_mb/aarch64/sm3_mb_ctx_asimd_aarch64.c	\

--- a/sm3_mb/aarch64/sm3_mb_ctx_sve2.c
+++ b/sm3_mb/aarch64/sm3_mb_ctx_sve2.c
@@ -1,0 +1,246 @@
+/**********************************************************************
+  Copyright(c) 2022 Arm Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Arm Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdint.h>
+#include <string.h>
+#include "sm3_mb.h"
+#include "memcpy_inline.h"
+#include "endian_helper.h"
+#define SM3_LOG2_BLOCK_SIZE 6
+void sm3_mb_mgr_init_sve2(SM3_MB_JOB_MGR * state);
+SM3_JOB *sm3_mb_mgr_submit_sve2(SM3_MB_JOB_MGR * state, SM3_JOB * job);
+SM3_JOB *sm3_mb_mgr_flush_sve2(SM3_MB_JOB_MGR * state);
+static inline void hash_init_digest(SM3_WORD_T * digest);
+static inline uint32_t hash_pad(uint8_t padblock[SM3_BLOCK_SIZE * 2], uint64_t total_len);
+static SM3_HASH_CTX *sm3_ctx_mgr_resubmit(SM3_HASH_CTX_MGR * mgr, SM3_HASH_CTX * ctx);
+
+void sm3_ctx_mgr_init_sve2(SM3_HASH_CTX_MGR * mgr)
+{
+	sm3_mb_mgr_init_sve2(&mgr->mgr);
+}
+
+SM3_HASH_CTX *sm3_ctx_mgr_submit_sve2(SM3_HASH_CTX_MGR * mgr, SM3_HASH_CTX * ctx,
+				      const void *buffer, uint32_t len, HASH_CTX_FLAG flags)
+{
+	if (flags & (~HASH_ENTIRE)) {
+		// User should not pass anything other than FIRST, UPDATE, or LAST
+		ctx->error = HASH_CTX_ERROR_INVALID_FLAGS;
+		return ctx;
+	}
+
+	if (ctx->status & HASH_CTX_STS_PROCESSING) {
+		// Cannot submit to a currently processing job.
+		ctx->error = HASH_CTX_ERROR_ALREADY_PROCESSING;
+		return ctx;
+	}
+
+	if ((ctx->status & HASH_CTX_STS_COMPLETE) && !(flags & HASH_FIRST)) {
+		// Cannot update a finished job.
+		ctx->error = HASH_CTX_ERROR_ALREADY_COMPLETED;
+		return ctx;
+	}
+
+	if (flags & HASH_FIRST) {
+		// Init digest
+		hash_init_digest(ctx->job.result_digest);
+
+		// Reset byte counter
+		ctx->total_length = 0;
+
+		// Clear extra blocks
+		ctx->partial_block_buffer_length = 0;
+	}
+	// If we made it here, there were no errors during this call to submit
+	ctx->error = HASH_CTX_ERROR_NONE;
+
+	// Store buffer ptr info from user
+	ctx->incoming_buffer = buffer;
+	ctx->incoming_buffer_length = len;
+
+	// Store the user's request flags and mark this ctx as currently being processed.
+	ctx->status = (flags & HASH_LAST) ?
+	    (HASH_CTX_STS) (HASH_CTX_STS_PROCESSING | HASH_CTX_STS_LAST) :
+	    HASH_CTX_STS_PROCESSING;
+
+	// Advance byte counter
+	ctx->total_length += len;
+
+	// If there is anything currently buffered in the extra blocks, append to it until it contains a whole block.
+	// Or if the user's buffer contains less than a whole block, append as much as possible to the extra block.
+	if ((ctx->partial_block_buffer_length) | (len < SM3_BLOCK_SIZE)) {
+		// Compute how many bytes to copy from user buffer into extra block
+		uint32_t copy_len = SM3_BLOCK_SIZE - ctx->partial_block_buffer_length;
+		if (len < copy_len)
+			copy_len = len;
+
+		if (copy_len) {
+			// Copy and update relevant pointers and counters
+			memcpy_fixedlen(&ctx->partial_block_buffer
+					[ctx->partial_block_buffer_length], buffer, copy_len);
+
+			ctx->partial_block_buffer_length += copy_len;
+			ctx->incoming_buffer = (const void *)((const char *)buffer + copy_len);
+			ctx->incoming_buffer_length = len - copy_len;
+		}
+		// The extra block should never contain more than 1 block here
+		assert(ctx->partial_block_buffer_length <= SM3_BLOCK_SIZE);
+
+		// If the extra block buffer contains exactly 1 block, it can be hashed.
+		if (ctx->partial_block_buffer_length >= SM3_BLOCK_SIZE) {
+			ctx->partial_block_buffer_length = 0;
+
+			ctx->job.buffer = ctx->partial_block_buffer;
+			ctx->job.len = 1;
+
+			ctx = (SM3_HASH_CTX *) sm3_mb_mgr_submit_sve2(&mgr->mgr, &ctx->job);
+		}
+	}
+
+	return sm3_ctx_mgr_resubmit(mgr, ctx);
+}
+
+SM3_HASH_CTX *sm3_ctx_mgr_flush_sve2(SM3_HASH_CTX_MGR * mgr)
+{
+	SM3_HASH_CTX *ctx;
+
+	while (1) {
+		ctx = (SM3_HASH_CTX *) sm3_mb_mgr_flush_sve2(&mgr->mgr);
+
+		// If flush returned 0, there are no more jobs in flight.
+		if (!ctx)
+			return NULL;
+
+		// If flush returned a job, verify that it is safe to return to the user.
+		// If it is not ready, resubmit the job to finish processing.
+		ctx = sm3_ctx_mgr_resubmit(mgr, ctx);
+
+		// If sm3_ctx_mgr_resubmit returned a job, it is ready to be returned.
+		if (ctx)
+			return ctx;
+
+		// Otherwise, all jobs currently being managed by the SM3_HASH_CTX_MGR still need processing. Loop.
+	}
+}
+
+static SM3_HASH_CTX *sm3_ctx_mgr_resubmit(SM3_HASH_CTX_MGR * mgr, SM3_HASH_CTX * ctx)
+{
+	while (ctx) {
+
+		if (ctx->status & HASH_CTX_STS_COMPLETE) {
+			ctx->status = HASH_CTX_STS_COMPLETE;	// Clear PROCESSING bit
+			return ctx;
+		}
+		// If the extra blocks are empty, begin hashing what remains in the user's buffer.
+		if (ctx->partial_block_buffer_length == 0 && ctx->incoming_buffer_length) {
+			const void *buffer = ctx->incoming_buffer;
+			uint32_t len = ctx->incoming_buffer_length;
+
+			// Only entire blocks can be hashed. Copy remainder to extra blocks buffer.
+			uint32_t copy_len = len & (SM3_BLOCK_SIZE - 1);
+
+			if (copy_len) {
+				len -= copy_len;
+				memcpy_fixedlen(ctx->partial_block_buffer,
+						((const char *)buffer + len), copy_len);
+				ctx->partial_block_buffer_length = copy_len;
+			}
+
+			ctx->incoming_buffer_length = 0;
+
+			// len should be a multiple of the block size now
+			assert((len % SM3_BLOCK_SIZE) == 0);
+
+			// Set len to the number of blocks to be hashed in the user's buffer
+			len >>= SM3_LOG2_BLOCK_SIZE;
+
+			if (len) {
+				ctx->job.buffer = (uint8_t *) buffer;
+				ctx->job.len = len;
+				ctx = (SM3_HASH_CTX *) sm3_mb_mgr_submit_sve2(&mgr->mgr,
+									      &ctx->job);
+				continue;
+			}
+		}
+		// If the extra blocks are not empty, then we are either on the last block(s)
+		// or we need more user input before continuing.
+		if (ctx->status & HASH_CTX_STS_LAST) {
+			uint8_t *buf = ctx->partial_block_buffer;
+			uint32_t n_extra_blocks = hash_pad(buf, ctx->total_length);
+
+			ctx->status =
+			    (HASH_CTX_STS) (HASH_CTX_STS_PROCESSING | HASH_CTX_STS_COMPLETE);
+			ctx->job.buffer = buf;
+			ctx->job.len = (uint32_t) n_extra_blocks;
+			ctx = (SM3_HASH_CTX *) sm3_mb_mgr_submit_sve2(&mgr->mgr, &ctx->job);
+			continue;
+		}
+
+		if (ctx)
+			ctx->status = HASH_CTX_STS_IDLE;
+		return ctx;
+	}
+
+	return NULL;
+}
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define cpu_to_be32(v) (((v&0xff000000)>>24) | ((v&0xff0000)>>8) | ((v&0xff00)<<8) | ((v&0xff)<<24))
+#else
+#define cpu_to_be32(v)
+#endif
+static inline void hash_init_digest(SM3_WORD_T * digest)
+{
+	static const SM3_WORD_T hash_initial_digest[SM3_DIGEST_NWORDS] =
+	    { cpu_to_be32(0x7380166f), cpu_to_be32(0x4914b2b9),
+		cpu_to_be32(0x172442d7), cpu_to_be32(0xda8a0600),
+		cpu_to_be32(0xa96f30bc), cpu_to_be32(0x163138aa),
+		cpu_to_be32(0xe38dee4d), cpu_to_be32(0xb0fb0e4e)
+	};
+	memcpy_fixedlen(digest, hash_initial_digest, sizeof(hash_initial_digest));
+}
+
+static inline uint32_t hash_pad(uint8_t padblock[SM3_BLOCK_SIZE * 2], uint64_t total_len)
+{
+	uint32_t i = (uint32_t) (total_len & (SM3_BLOCK_SIZE - 1));
+
+	memclr_fixedlen(&padblock[i], SM3_BLOCK_SIZE);
+	padblock[i] = 0x80;
+
+	// Move i to the end of either 1st or 2nd extra block depending on length
+	i += ((SM3_BLOCK_SIZE - 1) & (0 - (total_len + SM3_PADLENGTHFIELD_SIZE + 1))) + 1 +
+	    SM3_PADLENGTHFIELD_SIZE;
+
+#if SM3_PADLENGTHFIELD_SIZE == 16
+	*((uint64_t *) & padblock[i - 16]) = 0;
+#endif
+
+	*((uint64_t *) & padblock[i - 8]) = to_be64((uint64_t) total_len << 3);
+
+	return i >> SM3_LOG2_BLOCK_SIZE;	// Number of extra blocks to hash
+}

--- a/sm3_mb/aarch64/sm3_mb_mgr_sve2.c
+++ b/sm3_mb/aarch64/sm3_mb_mgr_sve2.c
@@ -38,7 +38,7 @@
 #define min(a,b)            (((a) < (b)) ? (a) : (b))
 #endif
 
-extern void sm3_mb_sve(int blocks, int total_lanes, SM3_JOB **);
+extern void sm3_mb_sve2(int blocks, int total_lanes, SM3_JOB **);
 extern void sm3_mb_asimd_x4(SM3_JOB *, SM3_JOB *, SM3_JOB *, SM3_JOB *, int);
 extern void sm3_mb_asimd_x1(SM3_JOB *, int);
 extern int sm3_mb_sve_max_lanes(void);
@@ -51,7 +51,7 @@ extern int sm3_mb_sve_max_lanes(void);
 	(((state->lens[i]&(~0xf))==0) && state->ldata[i].job_in_lane==NULL)
 #define LANE_IS_INVALID(state,i)	\
 	(((state->lens[i]&(~0xf))!=0) && state->ldata[i].job_in_lane==NULL)
-void sm3_mb_mgr_init_sve(SM3_MB_JOB_MGR * state)
+void sm3_mb_mgr_init_sve2(SM3_MB_JOB_MGR * state)
 {
 	unsigned int i;
 	int maxjobs = sm3_mb_sve_max_lanes();
@@ -107,7 +107,7 @@ static int sm3_mb_mgr_do_jobs(SM3_MB_JOB_MGR * state)
 	blocks = len >> 4;
 
 	if (lanes >= 4 && (lanes >= maxjobs - 2)) {
-		sm3_mb_sve(blocks, lanes, job_vecs);
+		sm3_mb_sve2(blocks, lanes, job_vecs);
 	} else {
 		i = 0;
 		while (i + 3 < lanes) {
@@ -162,7 +162,7 @@ static void sm3_mb_mgr_insert_job(SM3_MB_JOB_MGR * state, SM3_JOB * job)
 	state->num_lanes_inuse++;
 }
 
-SM3_JOB *sm3_mb_mgr_submit_sve(SM3_MB_JOB_MGR * state, SM3_JOB * job)
+SM3_JOB *sm3_mb_mgr_submit_sve2(SM3_MB_JOB_MGR * state, SM3_JOB * job)
 {
 #ifndef NDEBUG
 	int lane_idx;
@@ -195,7 +195,7 @@ SM3_JOB *sm3_mb_mgr_submit_sve(SM3_MB_JOB_MGR * state, SM3_JOB * job)
 	return ret;
 }
 
-SM3_JOB *sm3_mb_mgr_flush_sve(SM3_MB_JOB_MGR * state)
+SM3_JOB *sm3_mb_mgr_flush_sve2(SM3_MB_JOB_MGR * state)
 {
 	SM3_JOB *ret;
 

--- a/sm3_mb/aarch64/sm3_mb_sve.S
+++ b/sm3_mb/aarch64/sm3_mb_sve.S
@@ -26,21 +26,24 @@
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **********************************************************************/
-
+#if defined(NO_SVE2)
 	.arch armv8.2-a+sve
+#else
+	.arch armv8.2-a+sve2
+#endif
 
 .macro copy_mb_16words vecs:req,dest:req
 	mov	src,\vecs
 	mov	dst,\dest
 	mov	ctr,lanes
-1:
+20:
 	ldr	tmp,[src],8
 	ldr	tmp,[tmp]
 	add	tmp,tmp,block_ctr,lsl 6
 	ld1	{TMPV0.4s,TMPV1.4s,TMPV2.4s,TMPV3.4s}, [tmp]
 	st1	{TMPV0.4s,TMPV1.4s,TMPV2.4s,TMPV3.4s}, [dst],64
 	subs	ctr,ctr,1
-	b.ne	1b
+	b.ne	20b
 .endm
 
 .macro load_words windex:req
@@ -66,7 +69,7 @@ sm3_mb_sve_max_lanes:
 	ret
 	.size sm3_mb_sve_max_lanes, .-sm3_mb_sve_max_lanes
 /*
- *  void sm3_mb_sve(int blocks, int total_lanes, SM3_JOB **job_vec)
+ *  void sm3_mb_sve/sve2(int blocks, int total_lanes, SM3_JOB **job_vec)
  */
 	num_blocks	.req	w0
 	total_lanes	.req	w1
@@ -88,10 +91,8 @@ sm3_mb_sve_max_lanes:
 	abcd_buf	.req	x14
 	sm3const_adr	.req	x15
 
-	.global sm3_mb_sve
-	.type sm3_mb_sve, %function
-sm3_mb_sve:
-	cbz	num_blocks,.return
+.macro IMPLEMENT_SM3_MB sve2_flag:req
+	cbz	num_blocks,10f
 	sm3_sve_save_stack
 	mov	savedsp,sp
 	mov	lane_offset, #0
@@ -108,13 +109,13 @@ sm3_mb_sve:
 	sub	databuf,abcd_buf,tmp
 	mov	sp,databuf
 	adr	sm3const_adr,SM3_CONSTS
-.seg_loops:
+1:
 	mov	src,job_vec
 	mov	dst,abcd_buf
 	cntp	lanes,p0,p0.s
 	add	efgh_buf,abcd_buf,lanes,lsl 4
 	mov	ctr,lanes
-.ldr_hash:
+2:
 	ldr	tmp,[src],8
 	add	tmp,tmp,64
 	ld1	{v0.16b, v1.16b},[tmp]
@@ -123,18 +124,18 @@ sm3_mb_sve:
 	st1	{v0.16b},[dst],16
 	st1	{v1.16b},[efgh_buf],16
 	subs	ctr,ctr,1
-	bne	.ldr_hash
+	bne	2b
 	ld4w	{VA.s,VB.s,VC.s,VD.s},p0/z,[abcd_buf]
 	add	tmp,abcd_buf,lanes,lsl 4
 	ld4w	{VE.s,VF.s,VG.s,VH.s},p0/z,[tmp]
 	mov	block_ctr,0
 	// always unpredicated SVE mode in current settings
 	pred_mode=0
-.block_loop:
-	sm3_single
+3:
+	sm3_single \sve2_flag
 	add	block_ctr, block_ctr, 1
 	cmp	block_ctr_w,num_blocks
-	bne	.block_loop
+	bne	3b
 	st4w	{VA.s,VB.s,VC.s,VD.s},p0,[abcd_buf]
 	add	efgh_buf,abcd_buf,lanes,lsl 4
 	st4w	{VE.s,VF.s,VG.s,VH.s},p0,[efgh_buf]
@@ -142,7 +143,7 @@ sm3_mb_sve:
 	mov	src,abcd_buf
 	add	job_vec,job_vec,lanes,lsl 3
 	mov	ctr,lanes
-.str_hash:
+4:
 	ld1	{v0.16b},[src],16
 	ld1	{v1.16b},[efgh_buf],16
 	rev32	v0.16b,v0.16b
@@ -151,12 +152,30 @@ sm3_mb_sve:
 	add	tmp,tmp,64
 	st1	{v0.16b,v1.16b},[tmp]
 	subs	ctr,ctr,1
-	bne	.str_hash
+	bne	4b
 	incw	lane_offset_x
 	whilelo	p0.s,	lane_offset, total_lanes
-	b.mi	.seg_loops
+	b.mi	1b
 	mov	sp,savedsp
 	sm3_sve_restore_stack
-.return:
+10:
 	ret
+.endm
+
+	.global sm3_mb_sve
+	.type sm3_mb_sve, %function
+sm3_mb_sve:
+.sve_entry:
+	IMPLEMENT_SM3_MB 0
 	.size sm3_mb_sve, .-sm3_mb_sve
+
+	.global sm3_mb_sve2
+	.type sm3_mb_sve2, %function
+sm3_mb_sve2:
+#if	!defined(NO_SVE2)
+	IMPLEMENT_SM3_MB 1
+#else
+#warning "SVE2 has been bypassed in the build"
+	b	.sve_entry
+#endif
+	.size sm3_mb_sve2, .-sm3_mb_sve2

--- a/sm3_mb/aarch64/sm3_sve_common.S
+++ b/sm3_mb/aarch64/sm3_sve_common.S
@@ -87,7 +87,7 @@
 	.if	have_sve2 == 0
 		lsl	\tmp\().s,\in\().s,\bits
 	.else
-		movprfx	\out\().d,\in\().d
+		movprfx	\out,\in
 		xar	\out\().s,\out\().s,VZERO.s,32-\bits
 	.endif
 
@@ -136,7 +136,7 @@
 		eor	\ret\().d,\x\().d,\y\().d
 		sve_bitop	eor,\ret,\z
 	.else
-		movprfx	\ret\().d,\x\().d
+		movprfx	\ret,\x
 		eor3	\ret\().d,\ret\().d,\y\().d,\z\().d
 	.endif
 .endm
@@ -155,8 +155,8 @@
 		and	\tmp\().d,\x\().d,\y\().d
 		sve_bitop	orr,\ret,\tmp
 	.else
-		movprfx	\ret\().d,\x\().d
-		bsl	\ret\().d,\ret\().d,\y\().d,\z\().d
+		movprfx	\ret,\y
+		bsl	\ret\().d,\ret\().d,\z\().d,\x\().d
 	.endif
 .endm
 
@@ -386,8 +386,8 @@
 	.endr
 .endm
 
-.macro sm3_single	sve2:vararg
-	.ifnb	\sve2
+.macro sm3_single	sve2_flag:req
+	.if	\sve2_flag == 1
 		have_sve2 = 1
 	.else
 		have_sve2=0
@@ -410,7 +410,7 @@
 	revb	WORD2.s, p0/m, WORD2.s
 	revb	WORD3.s, p0/m, WORD3.s
 	.if     have_sve2 == 1
-		mov	VZERO.s,p0/m,#0
+		dup	VZERO.s,#0
 	.endif
 	sm3_exec
 .endm


### PR DESCRIPTION
Test result on N2/V1 micro-architecture:

+--------+-------------+-------------+------------+
|        | CPU1 (N2)   | CPU2 (N2)   | CPU3 (V1)  |
|        | 128-bit VL  | 128-bit VL  | 256-bit VL |
+--------+-------------+-------------+------------+
|  neon  |  397 MB/s   |  495 MB/s   |  464 MB/s  |
+--------+-------------+-------------+------------+
|  sve2  |  425 MB/s   |  516 MB/s   |            |
|        |   (+7%)     |  (+4.2%)    |
+--------+-------------+-------------+------------+
|  sve   |             |             |  652 MB/s  |
|        |             |             |    (+40%)  |
+--------+-------------+-------------+------------+

Change-Id: Ie73098d45a83eb438cdf3121d97d10e477ea9665
Signed-off-by: Daniel Hu <Daniel.Hu@arm.com>