### PR TITLE
Use embedded broadcast to replicate constants

### DIFF
--- a/include/reg_sizes.asm
+++ b/include/reg_sizes.asm
@@ -27,6 +27,9 @@
 ;  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+%use smartalign
+ALIGNMODE P6		; emit multibyte NOPs
+
 %ifndef _REG_SIZES_ASM_
 %define _REG_SIZES_ASM_
 

--- a/sha1_mb/sha1_mb_x16_avx512.asm
+++ b/sha1_mb/sha1_mb_x16_avx512.asm
@@ -89,6 +89,8 @@ section .text
 %define TMP0	zmm11
 %define TMP1	zmm12
 %define TMP2	zmm13
+%define TMP3	zmm14
+%define TMP4	zmm15
 
 %define W0	zmm16
 %define W1	zmm17
@@ -219,44 +221,44 @@ section .text
 ;; t0, r3, r1, r0, r2, r7, r5, r4, r6, r11, r9, r8, r10, r15, r13, r12
 ;; Can use t1 and r14 as scratch registers
 
-	vmovdqa32 %%r14, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r14, TMP3
 	vpermi2q  %%r14, %%t0, %%r2		; r14 = {h8  g8  f8  e8   d8  c8  b8  a8   h0 g0 f0 e0	 d0 c0 b0 a0}
-	vmovdqa32 %%t1,  [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%t1,  TMP4
 	vpermi2q  %%t1,  %%t0, %%r2		; t1  = {h12 g12 f12 e12  d12 c12 b12 a12  h4 g4 f4 e4	 d4 c4 b4 a4}
 
-	vmovdqa32 %%r2, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r2, TMP3
 	vpermi2q  %%r2, %%r3, %%r7		; r2  = {h9  g9  f9  e9   d9  c9  b9  a9   h1 g1 f1 e1	 d1 c1 b1 a1}
-	vmovdqa32 %%t0, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%t0, TMP4
 	vpermi2q  %%t0, %%r3, %%r7		; t0  = {h13 g13 f13 e13  d13 c13 b13 a13  h5 g5 f5 e5	 d5 c5 b5 a5}
 
-	vmovdqa32 %%r3, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r3, TMP3
 	vpermi2q  %%r3, %%r1, %%r5		; r3  = {h10 g10 f10 e10  d10 c10 b10 a10  h2 g2 f2 e2	 d2 c2 b2 a2}
-	vmovdqa32 %%r7, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r7, TMP4
 	vpermi2q  %%r7, %%r1, %%r5		; r7  = {h14 g14 f14 e14  d14 c14 b14 a14  h6 g6 f6 e6	 d6 c6 b6 a6}
 
-	vmovdqa32 %%r1, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r1, TMP3
 	vpermi2q  %%r1, %%r0, %%r4		; r1  = {h11 g11 f11 e11  d11 c11 b11 a11  h3 g3 f3 e3	 d3 c3 b3 a3}
-	vmovdqa32 %%r5, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r5, TMP4
 	vpermi2q  %%r5, %%r0, %%r4		; r5  = {h15 g15 f15 e15  d15 c15 b15 a15  h7 g7 f7 e7	 d7 c7 b7 a7}
 
-	vmovdqa32 %%r0, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r0, TMP3
 	vpermi2q  %%r0, %%r6, %%r10		; r0 = {p8  o8  n8  m8   l8  k8  j8  i8   p0 o0 n0 m0	 l0 k0 j0 i0}
-	vmovdqa32 %%r4,  [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r4,  TMP4
 	vpermi2q  %%r4, %%r6, %%r10		; r4  = {p12 o12 n12 m12  l12 k12 j12 i12  p4 o4 n4 m4	 l4 k4 j4 i4}
 
-	vmovdqa32 %%r6, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r6, TMP3
 	vpermi2q  %%r6, %%r11, %%r15		; r6  = {p9  o9  n9  m9   l9  k9  j9  i9   p1 o1 n1 m1	 l1 k1 j1 i1}
-	vmovdqa32 %%r10, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r10, TMP4
 	vpermi2q  %%r10, %%r11, %%r15		; r10 = {p13 o13 n13 m13  l13 k13 j13 i13  p5 o5 n5 m5	 l5 k5 j5 i5}
 
-	vmovdqa32 %%r11, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r11, TMP3
 	vpermi2q  %%r11, %%r9, %%r13		; r11 = {p10 o10 n10 m10  l10 k10 j10 i10  p2 o2 n2 m2	 l2 k2 j2 i2}
-	vmovdqa32 %%r15, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r15, TMP4
 	vpermi2q  %%r15, %%r9, %%r13		; r15 = {p14 o14 n14 m14  l14 k14 j14 i14  p6 o6 n6 m6	 l6 k6 j6 i6}
 
-	vmovdqa32 %%r9, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r9, TMP3
 	vpermi2q  %%r9, %%r8, %%r12		; r9  = {p11 o11 n11 m11  l11 k11 j11 i11  p3 o3 n3 m3	 l3 k3 j3 i3}
-	vmovdqa32 %%r13, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r13, TMP4
 	vpermi2q  %%r13, %%r8, %%r12		; r13 = {p15 o15 n15 m15  l15 k15 j15 i15  p7 o7 n7 m7	 l7 k7 j7 i7}
 
 ;; At this point r8 and r12 can be used as scratch registers
@@ -341,7 +343,7 @@ section .text
 %define %%WT	 %1
 %define %%OFFSET %2
 	mov		inp0, [IN + (%%OFFSET*8)]
-	vmovups		%%WT, [inp0+IDX]
+	vmovdqu32	%%WT, [inp0+IDX]
 %endmacro
 
 align 64
@@ -360,47 +362,53 @@ sha1_mb_x16_avx512:
 	vmovups	D, [DIGEST + 3*64]
 	vmovups	E, [DIGEST + 4*64]
 
+
+	
+	;; transpose input onto stack
+	lea	IDX, [IN]
+	mov	inp0, [IDX + 0*8]
+	mov	inp1, [IDX + 1*8]
+	mov	inp2, [IDX + 2*8]
+	mov	inp3, [IDX + 3*8]
+	mov	inp4, [IDX + 4*8]
+	mov	inp5, [IDX + 5*8]
+	mov	inp6, [IDX + 6*8]
+	mov	inp7, [IDX + 7*8]
+
+	vmovups	W0,[inp0]
+	vmovups	W1,[inp1]
+	vmovups	W2,[inp2]
+	vmovups	W3,[inp3]
+	vmovups	W4,[inp4]
+	vmovups	W5,[inp5]
+	vmovups	W6,[inp6]
+	vmovups	W7,[inp7]
+
+	mov	inp0, [IDX + 8*8]
+	mov	inp1, [IDX + 9*8]
+	mov	inp2, [IDX +10*8]
+	mov	inp3, [IDX +11*8]
+	mov	inp4, [IDX +12*8]
+	mov	inp5, [IDX +13*8]
+	mov	inp6, [IDX +14*8]
+	mov	inp7, [IDX +15*8]
+
+	vmovups	W8, [inp0]
+	vmovups	W9, [inp1]
+	vmovups	W10,[inp2]
+	vmovups	W11,[inp3]
+	vmovups	W12,[inp4]
+	vmovups	W13,[inp5]
+	vmovups	W14,[inp6]
+	vmovups	W15,[inp7]
+	lea	IDX, [PSHUFFLE_BYTE_FLIP_MASK]
+	vbroadcasti32x4	TMP2, [IDX]
+	vpmovzxbq TMP3, [IDX+16]	; MASK 1
+	vpmovzxbq TMP4, [IDX+16+8]	; MASK 2
 	xor IDX, IDX
 
-	;; transpose input onto stack
-	mov	inp0, [IN + 0*8]
-	mov	inp1, [IN + 1*8]
-	mov	inp2, [IN + 2*8]
-	mov	inp3, [IN + 3*8]
-	mov	inp4, [IN + 4*8]
-	mov	inp5, [IN + 5*8]
-	mov	inp6, [IN + 6*8]
-	mov	inp7, [IN + 7*8]
-
-	vmovups	W0,[inp0+IDX]
-	vmovups	W1,[inp1+IDX]
-	vmovups	W2,[inp2+IDX]
-	vmovups	W3,[inp3+IDX]
-	vmovups	W4,[inp4+IDX]
-	vmovups	W5,[inp5+IDX]
-	vmovups	W6,[inp6+IDX]
-	vmovups	W7,[inp7+IDX]
-
-	mov	inp0, [IN + 8*8]
-	mov	inp1, [IN + 9*8]
-	mov	inp2, [IN +10*8]
-	mov	inp3, [IN +11*8]
-	mov	inp4, [IN +12*8]
-	mov	inp5, [IN +13*8]
-	mov	inp6, [IN +14*8]
-	mov	inp7, [IN +15*8]
-
-	vmovups	W8, [inp0+IDX]
-	vmovups	W9, [inp1+IDX]
-	vmovups	W10,[inp2+IDX]
-	vmovups	W11,[inp3+IDX]
-	vmovups	W12,[inp4+IDX]
-	vmovups	W13,[inp5+IDX]
-	vmovups	W14,[inp6+IDX]
-	vmovups	W15,[inp7+IDX]
-
+align 32
 lloop:
-	vmovdqa32	TMP2, [PSHUFFLE_BYTE_FLIP_MASK]
 
 	add	IDX, 64
 
@@ -419,7 +427,7 @@ lloop:
 	vmovdqa32	DD, D
 	vmovdqa32	EE, E
 
-	vmovdqa32	KT, [K00_19]
+	vpbroadcastd	KT, [K00_19]
 %assign I 0xCA
 %assign J 0
 %assign K 2
@@ -430,13 +438,13 @@ lloop:
 	PROCESS_LOOP  APPEND(W,J),  I
 	MSG_SCHED_ROUND_16_79  APPEND(W,J), APPEND(W,K), APPEND(W,L), APPEND(W,M)
 	%if N = 19
-		vmovdqa32	KT, [K20_39]
+		vpbroadcastd	KT, [K20_39]
 		%assign I 0x96
 	%elif N = 39
-		vmovdqa32	KT, [K40_59]
+		vpbroadcastd	KT, [K40_59]
 		%assign I 0xE8
 	%elif N = 59
-		vmovdqa32	KT, [K60_79]
+		vpbroadcastd	KT, [K60_79]
 		%assign I 0x96
 	%endif
 %assign J ((J+1)% 16)
@@ -492,16 +500,11 @@ lastLoop:
 	vpaddd		E,E,EE
 
         ;; update into data pointers
-%assign I 0
-%rep 8
-        mov    inp0, [IN + (2*I)*8]
-        mov    inp1, [IN + (2*I +1)*8]
-        add    inp0, IDX
-        add    inp1, IDX
-        mov    [IN + (2*I)*8], inp0
-        mov    [IN + (2*I+1)*8], inp1
-%assign I (I+1)
-%endrep
+	vpbroadcastq TMP1, IDX
+	vpaddq TMP0, TMP1, [IN]
+	vpaddq TMP1, TMP1, [IN+64]
+	vmovdqu32 [IN], TMP0
+	vmovdqu32 [IN+64], TMP1
 
 	; Write out digest
 	; Do we need to untranspose digests???
@@ -515,45 +518,30 @@ lastLoop:
 
 section .data
 align 64
-K00_19:			dq 0x5A8279995A827999, 0x5A8279995A827999
-			dq 0x5A8279995A827999, 0x5A8279995A827999
-			dq 0x5A8279995A827999, 0x5A8279995A827999
-			dq 0x5A8279995A827999, 0x5A8279995A827999
-K20_39:                 dq 0x6ED9EBA16ED9EBA1, 0x6ED9EBA16ED9EBA1
-			dq 0x6ED9EBA16ED9EBA1, 0x6ED9EBA16ED9EBA1
-			dq 0x6ED9EBA16ED9EBA1, 0x6ED9EBA16ED9EBA1
-			dq 0x6ED9EBA16ED9EBA1, 0x6ED9EBA16ED9EBA1
-K40_59:                 dq 0x8F1BBCDC8F1BBCDC, 0x8F1BBCDC8F1BBCDC
-			dq 0x8F1BBCDC8F1BBCDC, 0x8F1BBCDC8F1BBCDC
-			dq 0x8F1BBCDC8F1BBCDC, 0x8F1BBCDC8F1BBCDC
-			dq 0x8F1BBCDC8F1BBCDC, 0x8F1BBCDC8F1BBCDC
-K60_79:                 dq 0xCA62C1D6CA62C1D6, 0xCA62C1D6CA62C1D6
-			dq 0xCA62C1D6CA62C1D6, 0xCA62C1D6CA62C1D6
-			dq 0xCA62C1D6CA62C1D6, 0xCA62C1D6CA62C1D6
-			dq 0xCA62C1D6CA62C1D6, 0xCA62C1D6CA62C1D6
+K00_19:			dd 0x5A827999
+K20_39:                 dd 0x6ED9EBA1
+K40_59:                 dd 0x8F1BBCDC
+K60_79:                 dd 0xCA62C1D6
 
 PSHUFFLE_BYTE_FLIP_MASK: dq 0x0405060700010203, 0x0c0d0e0f08090a0b
-			 dq 0x0405060700010203, 0x0c0d0e0f08090a0b
-			 dq 0x0405060700010203, 0x0c0d0e0f08090a0b
-			 dq 0x0405060700010203, 0x0c0d0e0f08090a0b
 
-PSHUFFLE_TRANSPOSE16_MASK1: 	dq 0x0000000000000000
-				dq 0x0000000000000001
-				dq 0x0000000000000008
-				dq 0x0000000000000009
-				dq 0x0000000000000004
-				dq 0x0000000000000005
-				dq 0x000000000000000C
-				dq 0x000000000000000D
+PSHUFFLE_TRANSPOSE16_MASK1: 	db 0x0
+				db 0x1
+				db 0x8
+				db 0x9
+				db 0x4
+				db 0x5
+				db 0xC
+				db 0xD
 
-PSHUFFLE_TRANSPOSE16_MASK2: 	dq 0x0000000000000002
-				dq 0x0000000000000003
-				dq 0x000000000000000A
-				dq 0x000000000000000B
-				dq 0x0000000000000006
-				dq 0x0000000000000007
-				dq 0x000000000000000E
-				dq 0x000000000000000F
+PSHUFFLE_TRANSPOSE16_MASK2: 	db 0x2
+				db 0x3
+				db 0xA
+				db 0xB
+				db 0x6
+				db 0x7
+				db 0xE
+				db 0xF
 
 %else
 %ifidn __OUTPUT_FORMAT__, win64

--- a/sha256_mb/sha256_mb_x16_avx512.asm
+++ b/sha256_mb/sha256_mb_x16_avx512.asm
@@ -230,44 +230,44 @@ FIELD	_rsp,		8,	8
 ;; t0, r3, r1, r0, r2, r7, r5, r4, r6, r11, r9, r8, r10, r15, r13, r12
 ;; Can use t1 and r14 as scratch registers
 
-	vmovdqa32 %%r14, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r14, TMP5
 	vpermi2q  %%r14, %%t0, %%r2		; r14 = {h8  g8  f8  e8   d8  c8  b8  a8   h0 g0 f0 e0	 d0 c0 b0 a0}
-	vmovdqa32 %%t1,  [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%t1,  TMP6
 	vpermi2q  %%t1,  %%t0, %%r2		; t1  = {h12 g12 f12 e12  d12 c12 b12 a12  h4 g4 f4 e4	 d4 c4 b4 a4}
 
-	vmovdqa32 %%r2, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r2, TMP5
 	vpermi2q  %%r2, %%r3, %%r7		; r2  = {h9  g9  f9  e9   d9  c9  b9  a9   h1 g1 f1 e1	 d1 c1 b1 a1}
-	vmovdqa32 %%t0, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%t0, TMP6
 	vpermi2q  %%t0, %%r3, %%r7		; t0  = {h13 g13 f13 e13  d13 c13 b13 a13  h5 g5 f5 e5	 d5 c5 b5 a5}
 
-	vmovdqa32 %%r3, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r3, TMP5
 	vpermi2q  %%r3, %%r1, %%r5		; r3  = {h10 g10 f10 e10  d10 c10 b10 a10  h2 g2 f2 e2	 d2 c2 b2 a2}
-	vmovdqa32 %%r7, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r7, TMP6
 	vpermi2q  %%r7, %%r1, %%r5		; r7  = {h14 g14 f14 e14  d14 c14 b14 a14  h6 g6 f6 e6	 d6 c6 b6 a6}
 
-	vmovdqa32 %%r1, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r1, TMP5
 	vpermi2q  %%r1, %%r0, %%r4		; r1  = {h11 g11 f11 e11  d11 c11 b11 a11  h3 g3 f3 e3	 d3 c3 b3 a3}
-	vmovdqa32 %%r5, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r5, TMP6
 	vpermi2q  %%r5, %%r0, %%r4		; r5  = {h15 g15 f15 e15  d15 c15 b15 a15  h7 g7 f7 e7	 d7 c7 b7 a7}
 
-	vmovdqa32 %%r0, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r0, TMP5
 	vpermi2q  %%r0, %%r6, %%r10		; r0 = {p8  o8  n8  m8   l8  k8  j8  i8   p0 o0 n0 m0	 l0 k0 j0 i0}
-	vmovdqa32 %%r4,  [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r4,  TMP6
 	vpermi2q  %%r4, %%r6, %%r10		; r4  = {p12 o12 n12 m12  l12 k12 j12 i12  p4 o4 n4 m4	 l4 k4 j4 i4}
 
-	vmovdqa32 %%r6, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r6, TMP5
 	vpermi2q  %%r6, %%r11, %%r15		; r6  = {p9  o9  n9  m9   l9  k9  j9  i9   p1 o1 n1 m1	 l1 k1 j1 i1}
-	vmovdqa32 %%r10, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r10, TMP6
 	vpermi2q  %%r10, %%r11, %%r15		; r10 = {p13 o13 n13 m13  l13 k13 j13 i13  p5 o5 n5 m5	 l5 k5 j5 i5}
 
-	vmovdqa32 %%r11, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r11, TMP5
 	vpermi2q  %%r11, %%r9, %%r13		; r11 = {p10 o10 n10 m10  l10 k10 j10 i10  p2 o2 n2 m2	 l2 k2 j2 i2}
-	vmovdqa32 %%r15, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r15, TMP6
 	vpermi2q  %%r15, %%r9, %%r13		; r15 = {p14 o14 n14 m14  l14 k14 j14 i14  p6 o6 n6 m6	 l6 k6 j6 i6}
 
-	vmovdqa32 %%r9, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r9, TMP5
 	vpermi2q  %%r9, %%r8, %%r12		; r9  = {p11 o11 n11 m11  l11 k11 j11 i11  p3 o3 n3 m3	 l3 k3 j3 i3}
-	vmovdqa32 %%r13, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r13, TMP6
 	vpermi2q  %%r13, %%r8, %%r12		; r13 = {p15 o15 n15 m15  l15 k15 j15 i15  p7 o7 n7 m7	 l7 k7 j7 i7}
 
 ;; At this point r8 and r12 can be used as scratch registers
@@ -331,7 +331,7 @@ FIELD	_rsp,		8,	8
 	;; H becomes T2, then add T1 for A
 	;; D becomes D + T1 for E
 
-	vpaddd		T1, H, TMP3		; T1 = H + Kt
+	vpaddd		T1, H, [TBL + ((%%ROUND)*4)]{1to16}	; T1 = H + Kt
 	vmovdqa32	TMP0, E
 	vprord		TMP1, E, 6 		; ROR_6(E)
 	vprord		TMP2, E, 11 		; ROR_11(E)
@@ -351,8 +351,6 @@ FIELD	_rsp,		8,	8
 	vpternlogd	H, TMP2, TMP3, 0x96	; H(T2) = SIGMA0(A)
 	vpaddd		H, H, TMP0		; H(T2) = SIGMA0(A) + MAJ(A,B,C)
 	vpaddd		H, H, T1		; H(A) = H(T2) + T1
-
-	vmovdqa32	TMP3, [TBL + ((%%ROUND+1)*64)]	; Next Kt
 
 	;; Rotate the args A-H (rotation of names associated with regs)
 	ROTATE_ARGS
@@ -388,7 +386,7 @@ FIELD	_rsp,		8,	8
 	vpternlogd	TMP0, F, G, 0xCA	; TMP0 = CH(E,F,G)
 	vpaddd		T1, H, %%WT		; T1 = H + Wt
 	vpternlogd	TMP1, TMP2, TMP3, 0x96	; TMP1 = SIGMA1(E)
-	vpaddd		T1, T1, TMP6		; T1 = T1 + Kt
+	vpaddd		T1, T1, [TBL + ((%%ROUND)*4)] {1to16}		; T1 = T1 + Kt
 	vprord		H, A, 2 		; ROR_2(A)
 	vpaddd		T1, T1, TMP0		; T1 = T1 + CH(E,F,G)
 	vprord		TMP2, A, 13 		; ROR_13(A)
@@ -398,22 +396,21 @@ FIELD	_rsp,		8,	8
 	vpternlogd	TMP0, B, C, 0xE8	; TMP0 = MAJ(A,B,C)
 	vpaddd		D, D, T1		; D = D + T1
 	vpternlogd	H, TMP2, TMP3, 0x96	; H(T2) = SIGMA0(A)
-	vprord		TMP4, %%WTp14, 17 	; ROR_17(Wt-2)
 	vpaddd		H, H, TMP0		; H(T2) = SIGMA0(A) + MAJ(A,B,C)
-	vprord		TMP5, %%WTp14, 19 	; ROR_19(Wt-2)
-	vpsrld		TMP6, %%WTp14, 10 	; SHR_10(Wt-2)
+	vprord		TMP0, %%WTp14, 17 	; ROR_17(Wt-2)
+	vprord		TMP1, %%WTp14, 19 	; ROR_19(Wt-2)
+	vpsrld		TMP2, %%WTp14, 10 	; SHR_10(Wt-2)
 	vpaddd		H, H, T1		; H(A) = H(T2) + T1
-	vpternlogd	TMP4, TMP5, TMP6, 0x96	; TMP4 = sigma1(Wt-2)
-	vpaddd		%%WT, %%WT, TMP4	; Wt = Wt-16 + sigma1(Wt-2)
-	vprord		TMP4, %%WTp1, 7 	; ROR_7(Wt-15)
-	vprord		TMP5, %%WTp1, 18 	; ROR_18(Wt-15)
+	vpternlogd	TMP0, TMP1, TMP2, 0x96	; TMP0 = sigma1(Wt-2)
+	vpaddd		%%WT, %%WT, TMP0	; Wt = Wt-16 + sigma1(Wt-2)
+	vprord		TMP0, %%WTp1, 7 	; ROR_7(Wt-15)
+	vprord		TMP1, %%WTp1, 18 	; ROR_18(Wt-15)
 	vpaddd		%%WT, %%WT, %%WTp9	; Wt = Wt-16 + sigma1(Wt-2) + Wt-7
-	vpsrld		TMP6, %%WTp1, 3 	; SHR_3(Wt-15)
-	vpternlogd	TMP4, TMP5, TMP6, 0x96	; TMP4 = sigma0(Wt-15)
-	vpaddd		%%WT, %%WT, TMP4	; Wt = Wt-16 + sigma1(Wt-2) +
+	vpsrld		TMP2, %%WTp1, 3 	; SHR_3(Wt-15)
+	vpternlogd	TMP0, TMP1, TMP2, 0x96	; TMP0 = sigma0(Wt-15)
+	vpaddd		%%WT, %%WT, TMP0	; Wt = Wt-16 + sigma1(Wt-2) +
 						;      Wt-7 + sigma0(Wt-15) +
 
-	vmovdqa32	TMP6, [TBL + ((%%ROUND+1)*64)]	; Next Kt
 
 	;; Rotate the args A-H (rotation of names associated with regs)
 	ROTATE_ARGS
@@ -424,20 +421,20 @@ FIELD	_rsp,		8,	8
 %define %%WTp1	%2
 %define %%WTp9	%3
 %define %%WTp14	%4
-	vprord		TMP4, %%WTp14, 17 	; ROR_17(Wt-2)
-	vprord		TMP5, %%WTp14, 19 	; ROR_19(Wt-2)
-	vpsrld		TMP6, %%WTp14, 10 	; SHR_10(Wt-2)
-	vpternlogd	TMP4, TMP5, TMP6, 0x96	; TMP4 = sigma1(Wt-2)
+	vprord		TMP0, %%WTp14, 17 	; ROR_17(Wt-2)
+	vprord		TMP1, %%WTp14, 19 	; ROR_19(Wt-2)
+	vpsrld		TMP2, %%WTp14, 10 	; SHR_10(Wt-2)
+	vpternlogd	TMP0, TMP1, TMP2, 0x96	; TMP0 = sigma1(Wt-2)
 
-	vpaddd		%%WT, %%WT, TMP4	; Wt = Wt-16 + sigma1(Wt-2)
+	vpaddd		%%WT, %%WT, TMP0	; Wt = Wt-16 + sigma1(Wt-2)
 	vpaddd		%%WT, %%WT, %%WTp9	; Wt = Wt-16 + sigma1(Wt-2) + Wt-7
 
-	vprord		TMP4, %%WTp1, 7 	; ROR_7(Wt-15)
-	vprord		TMP5, %%WTp1, 18 	; ROR_18(Wt-15)
-	vpsrld		TMP6, %%WTp1, 3 	; SHR_3(Wt-15)
-	vpternlogd	TMP4, TMP5, TMP6, 0x96	; TMP4 = sigma0(Wt-15)
+	vprord		TMP0, %%WTp1, 7 	; ROR_7(Wt-15)
+	vprord		TMP1, %%WTp1, 18 	; ROR_18(Wt-15)
+	vpsrld		TMP2, %%WTp1, 3 	; SHR_3(Wt-15)
+	vpternlogd	TMP0, TMP1, TMP2, 0x96	; TMP0 = sigma0(Wt-15)
 
-	vpaddd		%%WT, %%WT, TMP4	; Wt = Wt-16 + sigma1(Wt-2) +
+	vpaddd		%%WT, %%WT, TMP0	; Wt = Wt-16 + sigma1(Wt-2) +
 						;      Wt-7 + sigma0(Wt-15) +
 %endmacro
 
@@ -477,51 +474,55 @@ sha256_mb_x16_avx512:
 	; Do we need to transpose digests???
 	; SHA1 does not, but SHA256 has been
 
-	xor IDX, IDX
 
 	;; Read in first block of input data
 	;; Transpose input data
-	mov	inp0, [IN + 0*8]
-	mov	inp1, [IN + 1*8]
-	mov	inp2, [IN + 2*8]
-	mov	inp3, [IN + 3*8]
-	mov	inp4, [IN + 4*8]
-	mov	inp5, [IN + 5*8]
-	mov	inp6, [IN + 6*8]
-	mov	inp7, [IN + 7*8]
+	lea	IDX,  [IN]
+	mov	inp0, [IDX + 0*8]
+	mov	inp1, [IDX + 1*8]
+	mov	inp2, [IDX + 2*8]
+	mov	inp3, [IDX + 3*8]
+	mov	inp4, [IDX + 4*8]
+	mov	inp5, [IDX + 5*8]
+	mov	inp6, [IDX + 6*8]
+	mov	inp7, [IDX + 7*8]
 
-	vmovups	W0,[inp0+IDX]
-	vmovups	W1,[inp1+IDX]
-	vmovups	W2,[inp2+IDX]
-	vmovups	W3,[inp3+IDX]
-	vmovups	W4,[inp4+IDX]
-	vmovups	W5,[inp5+IDX]
-	vmovups	W6,[inp6+IDX]
-	vmovups	W7,[inp7+IDX]
+	vmovups	W0,[inp0]
+	vmovups	W1,[inp1]
+	vmovups	W2,[inp2]
+	vmovups	W3,[inp3]
+	vmovups	W4,[inp4]
+	vmovups	W5,[inp5]
+	vmovups	W6,[inp6]
+	vmovups	W7,[inp7]
 
-	mov	inp0, [IN + 8*8]
-	mov	inp1, [IN + 9*8]
-	mov	inp2, [IN +10*8]
-	mov	inp3, [IN +11*8]
-	mov	inp4, [IN +12*8]
-	mov	inp5, [IN +13*8]
-	mov	inp6, [IN +14*8]
-	mov	inp7, [IN +15*8]
+	mov	inp0, [IDX + 8*8]
+	mov	inp1, [IDX + 9*8]
+	mov	inp2, [IDX +10*8]
+	mov	inp3, [IDX +11*8]
+	mov	inp4, [IDX +12*8]
+	mov	inp5, [IDX +13*8]
+	mov	inp6, [IDX +14*8]
+	mov	inp7, [IDX +15*8]
 
-	vmovups	W8, [inp0+IDX]
-	vmovups	W9, [inp1+IDX]
-	vmovups	W10,[inp2+IDX]
-	vmovups	W11,[inp3+IDX]
-	vmovups	W12,[inp4+IDX]
-	vmovups	W13,[inp5+IDX]
-	vmovups	W14,[inp6+IDX]
-	vmovups	W15,[inp7+IDX]
+	vmovups	W8, [inp0]
+	vmovups	W9, [inp1]
+	vmovups	W10,[inp2]
+	vmovups	W11,[inp3]
+	vmovups	W12,[inp4]
+	vmovups	W13,[inp5]
+	vmovups	W14,[inp6]
+	vmovups	W15,[inp7]
+	lea	IDX, [PSHUFFLE_BYTE_FLIP_MASK]
+	vbroadcasti32x4 TMP4, [IDX]   ; PSHUFFLE_BYTE_FLIP_MASK
+	vpmovzxbq	TMP5, [IDX+16]; PSHUFFLE_TRANSPOSE16_MASK1
+	vpmovzxbq	TMP6, [IDX+16+8]; PSHUFFLE_TRANSPOSE16_MASK2
+	xor IDX, IDX
 
 
+align 32
 lloop:
-	vmovdqa32	TMP2, [PSHUFFLE_BYTE_FLIP_MASK]
 
-	vmovdqa32	TMP3, [TBL]	; First K
 
 	; Save digests for later addition
         vmovdqa32	[rsp + _DIGEST_SAVE + 64*0], A
@@ -539,7 +540,7 @@ lloop:
 
 %assign I 0
 %rep 16
-       	vpshufb	APPEND(W,I), APPEND(W,I), TMP2
+       	vpshufb	APPEND(W,I), APPEND(W,I), TMP4
 %assign I (I+1)
 %endrep
 
@@ -591,6 +592,7 @@ lloop:
 
 	jmp	lloop
 
+align 16
 lastLoop:
 	; Process last 16 rounds
 %assign I 48
@@ -612,16 +614,11 @@ lastLoop:
         vpaddd		H, H, [rsp + _DIGEST_SAVE + 64*7]
 
         ;; update into data pointers
-%assign I 0
-%rep 8
-        mov    inp0, [IN + (2*I)*8]
-        mov    inp1, [IN + (2*I +1)*8]
-        add    inp0, IDX
-        add    inp1, IDX
-        mov    [IN + (2*I)*8], inp0
-        mov    [IN + (2*I+1)*8], inp1
-%assign I (I+1)
-%endrep
+	vpbroadcastq TMP1, IDX
+	vpaddq	TMP0, TMP1, [IN]
+	vpaddq	TMP1, TMP1, [IN+64]
+	vmovdqu32 [IN], TMP0
+	vmovdqu32  [IN+64], TMP1
 
 	; Write out digest
 	; Do we need to untranspose digests???
@@ -641,286 +638,91 @@ lastLoop:
         section .data
 align 64
 TABLE:
-	dq	0x428a2f98428a2f98, 0x428a2f98428a2f98
-	dq	0x428a2f98428a2f98, 0x428a2f98428a2f98
-	dq	0x428a2f98428a2f98, 0x428a2f98428a2f98
-	dq	0x428a2f98428a2f98, 0x428a2f98428a2f98
-	dq	0x7137449171374491, 0x7137449171374491
-	dq	0x7137449171374491, 0x7137449171374491
-	dq	0x7137449171374491, 0x7137449171374491
-	dq	0x7137449171374491, 0x7137449171374491
-	dq	0xb5c0fbcfb5c0fbcf, 0xb5c0fbcfb5c0fbcf
-	dq	0xb5c0fbcfb5c0fbcf, 0xb5c0fbcfb5c0fbcf
-	dq	0xb5c0fbcfb5c0fbcf, 0xb5c0fbcfb5c0fbcf
-	dq	0xb5c0fbcfb5c0fbcf, 0xb5c0fbcfb5c0fbcf
-	dq	0xe9b5dba5e9b5dba5, 0xe9b5dba5e9b5dba5
-	dq	0xe9b5dba5e9b5dba5, 0xe9b5dba5e9b5dba5
-	dq	0xe9b5dba5e9b5dba5, 0xe9b5dba5e9b5dba5
-	dq	0xe9b5dba5e9b5dba5, 0xe9b5dba5e9b5dba5
-	dq	0x3956c25b3956c25b, 0x3956c25b3956c25b
-	dq	0x3956c25b3956c25b, 0x3956c25b3956c25b
-	dq	0x3956c25b3956c25b, 0x3956c25b3956c25b
-	dq	0x3956c25b3956c25b, 0x3956c25b3956c25b
-	dq	0x59f111f159f111f1, 0x59f111f159f111f1
-	dq	0x59f111f159f111f1, 0x59f111f159f111f1
-	dq	0x59f111f159f111f1, 0x59f111f159f111f1
-	dq	0x59f111f159f111f1, 0x59f111f159f111f1
-	dq	0x923f82a4923f82a4, 0x923f82a4923f82a4
-	dq	0x923f82a4923f82a4, 0x923f82a4923f82a4
-	dq	0x923f82a4923f82a4, 0x923f82a4923f82a4
-	dq	0x923f82a4923f82a4, 0x923f82a4923f82a4
-	dq	0xab1c5ed5ab1c5ed5, 0xab1c5ed5ab1c5ed5
-	dq	0xab1c5ed5ab1c5ed5, 0xab1c5ed5ab1c5ed5
-	dq	0xab1c5ed5ab1c5ed5, 0xab1c5ed5ab1c5ed5
-	dq	0xab1c5ed5ab1c5ed5, 0xab1c5ed5ab1c5ed5
-	dq	0xd807aa98d807aa98, 0xd807aa98d807aa98
-	dq	0xd807aa98d807aa98, 0xd807aa98d807aa98
-	dq	0xd807aa98d807aa98, 0xd807aa98d807aa98
-	dq	0xd807aa98d807aa98, 0xd807aa98d807aa98
-	dq	0x12835b0112835b01, 0x12835b0112835b01
-	dq	0x12835b0112835b01, 0x12835b0112835b01
-	dq	0x12835b0112835b01, 0x12835b0112835b01
-	dq	0x12835b0112835b01, 0x12835b0112835b01
-	dq	0x243185be243185be, 0x243185be243185be
-	dq	0x243185be243185be, 0x243185be243185be
-	dq	0x243185be243185be, 0x243185be243185be
-	dq	0x243185be243185be, 0x243185be243185be
-	dq	0x550c7dc3550c7dc3, 0x550c7dc3550c7dc3
-	dq	0x550c7dc3550c7dc3, 0x550c7dc3550c7dc3
-	dq	0x550c7dc3550c7dc3, 0x550c7dc3550c7dc3
-	dq	0x550c7dc3550c7dc3, 0x550c7dc3550c7dc3
-	dq	0x72be5d7472be5d74, 0x72be5d7472be5d74
-	dq	0x72be5d7472be5d74, 0x72be5d7472be5d74
-	dq	0x72be5d7472be5d74, 0x72be5d7472be5d74
-	dq	0x72be5d7472be5d74, 0x72be5d7472be5d74
-	dq	0x80deb1fe80deb1fe, 0x80deb1fe80deb1fe
-	dq	0x80deb1fe80deb1fe, 0x80deb1fe80deb1fe
-	dq	0x80deb1fe80deb1fe, 0x80deb1fe80deb1fe
-	dq	0x80deb1fe80deb1fe, 0x80deb1fe80deb1fe
-	dq	0x9bdc06a79bdc06a7, 0x9bdc06a79bdc06a7
-	dq	0x9bdc06a79bdc06a7, 0x9bdc06a79bdc06a7
-	dq	0x9bdc06a79bdc06a7, 0x9bdc06a79bdc06a7
-	dq	0x9bdc06a79bdc06a7, 0x9bdc06a79bdc06a7
-	dq	0xc19bf174c19bf174, 0xc19bf174c19bf174
-	dq	0xc19bf174c19bf174, 0xc19bf174c19bf174
-	dq	0xc19bf174c19bf174, 0xc19bf174c19bf174
-	dq	0xc19bf174c19bf174, 0xc19bf174c19bf174
-	dq	0xe49b69c1e49b69c1, 0xe49b69c1e49b69c1
-	dq	0xe49b69c1e49b69c1, 0xe49b69c1e49b69c1
-	dq	0xe49b69c1e49b69c1, 0xe49b69c1e49b69c1
-	dq	0xe49b69c1e49b69c1, 0xe49b69c1e49b69c1
-	dq	0xefbe4786efbe4786, 0xefbe4786efbe4786
-	dq	0xefbe4786efbe4786, 0xefbe4786efbe4786
-	dq	0xefbe4786efbe4786, 0xefbe4786efbe4786
-	dq	0xefbe4786efbe4786, 0xefbe4786efbe4786
-	dq	0x0fc19dc60fc19dc6, 0x0fc19dc60fc19dc6
-	dq	0x0fc19dc60fc19dc6, 0x0fc19dc60fc19dc6
-	dq	0x0fc19dc60fc19dc6, 0x0fc19dc60fc19dc6
-	dq	0x0fc19dc60fc19dc6, 0x0fc19dc60fc19dc6
-	dq	0x240ca1cc240ca1cc, 0x240ca1cc240ca1cc
-	dq	0x240ca1cc240ca1cc, 0x240ca1cc240ca1cc
-	dq	0x240ca1cc240ca1cc, 0x240ca1cc240ca1cc
-	dq	0x240ca1cc240ca1cc, 0x240ca1cc240ca1cc
-	dq	0x2de92c6f2de92c6f, 0x2de92c6f2de92c6f
-	dq	0x2de92c6f2de92c6f, 0x2de92c6f2de92c6f
-	dq	0x2de92c6f2de92c6f, 0x2de92c6f2de92c6f
-	dq	0x2de92c6f2de92c6f, 0x2de92c6f2de92c6f
-	dq	0x4a7484aa4a7484aa, 0x4a7484aa4a7484aa
-	dq	0x4a7484aa4a7484aa, 0x4a7484aa4a7484aa
-	dq	0x4a7484aa4a7484aa, 0x4a7484aa4a7484aa
-	dq	0x4a7484aa4a7484aa, 0x4a7484aa4a7484aa
-	dq	0x5cb0a9dc5cb0a9dc, 0x5cb0a9dc5cb0a9dc
-	dq	0x5cb0a9dc5cb0a9dc, 0x5cb0a9dc5cb0a9dc
-	dq	0x5cb0a9dc5cb0a9dc, 0x5cb0a9dc5cb0a9dc
-	dq	0x5cb0a9dc5cb0a9dc, 0x5cb0a9dc5cb0a9dc
-	dq	0x76f988da76f988da, 0x76f988da76f988da
-	dq	0x76f988da76f988da, 0x76f988da76f988da
-	dq	0x76f988da76f988da, 0x76f988da76f988da
-	dq	0x76f988da76f988da, 0x76f988da76f988da
-	dq	0x983e5152983e5152, 0x983e5152983e5152
-	dq	0x983e5152983e5152, 0x983e5152983e5152
-	dq	0x983e5152983e5152, 0x983e5152983e5152
-	dq	0x983e5152983e5152, 0x983e5152983e5152
-	dq	0xa831c66da831c66d, 0xa831c66da831c66d
-	dq	0xa831c66da831c66d, 0xa831c66da831c66d
-	dq	0xa831c66da831c66d, 0xa831c66da831c66d
-	dq	0xa831c66da831c66d, 0xa831c66da831c66d
-	dq	0xb00327c8b00327c8, 0xb00327c8b00327c8
-	dq	0xb00327c8b00327c8, 0xb00327c8b00327c8
-	dq	0xb00327c8b00327c8, 0xb00327c8b00327c8
-	dq	0xb00327c8b00327c8, 0xb00327c8b00327c8
-	dq	0xbf597fc7bf597fc7, 0xbf597fc7bf597fc7
-	dq	0xbf597fc7bf597fc7, 0xbf597fc7bf597fc7
-	dq	0xbf597fc7bf597fc7, 0xbf597fc7bf597fc7
-	dq	0xbf597fc7bf597fc7, 0xbf597fc7bf597fc7
-	dq	0xc6e00bf3c6e00bf3, 0xc6e00bf3c6e00bf3
-	dq	0xc6e00bf3c6e00bf3, 0xc6e00bf3c6e00bf3
-	dq	0xc6e00bf3c6e00bf3, 0xc6e00bf3c6e00bf3
-	dq	0xc6e00bf3c6e00bf3, 0xc6e00bf3c6e00bf3
-	dq	0xd5a79147d5a79147, 0xd5a79147d5a79147
-	dq	0xd5a79147d5a79147, 0xd5a79147d5a79147
-	dq	0xd5a79147d5a79147, 0xd5a79147d5a79147
-	dq	0xd5a79147d5a79147, 0xd5a79147d5a79147
-	dq	0x06ca635106ca6351, 0x06ca635106ca6351
-	dq	0x06ca635106ca6351, 0x06ca635106ca6351
-	dq	0x06ca635106ca6351, 0x06ca635106ca6351
-	dq	0x06ca635106ca6351, 0x06ca635106ca6351
-	dq	0x1429296714292967, 0x1429296714292967
-	dq	0x1429296714292967, 0x1429296714292967
-	dq	0x1429296714292967, 0x1429296714292967
-	dq	0x1429296714292967, 0x1429296714292967
-	dq	0x27b70a8527b70a85, 0x27b70a8527b70a85
-	dq	0x27b70a8527b70a85, 0x27b70a8527b70a85
-	dq	0x27b70a8527b70a85, 0x27b70a8527b70a85
-	dq	0x27b70a8527b70a85, 0x27b70a8527b70a85
-	dq	0x2e1b21382e1b2138, 0x2e1b21382e1b2138
-	dq	0x2e1b21382e1b2138, 0x2e1b21382e1b2138
-	dq	0x2e1b21382e1b2138, 0x2e1b21382e1b2138
-	dq	0x2e1b21382e1b2138, 0x2e1b21382e1b2138
-	dq	0x4d2c6dfc4d2c6dfc, 0x4d2c6dfc4d2c6dfc
-	dq	0x4d2c6dfc4d2c6dfc, 0x4d2c6dfc4d2c6dfc
-	dq	0x4d2c6dfc4d2c6dfc, 0x4d2c6dfc4d2c6dfc
-	dq	0x4d2c6dfc4d2c6dfc, 0x4d2c6dfc4d2c6dfc
-	dq	0x53380d1353380d13, 0x53380d1353380d13
-	dq	0x53380d1353380d13, 0x53380d1353380d13
-	dq	0x53380d1353380d13, 0x53380d1353380d13
-	dq	0x53380d1353380d13, 0x53380d1353380d13
-	dq	0x650a7354650a7354, 0x650a7354650a7354
-	dq	0x650a7354650a7354, 0x650a7354650a7354
-	dq	0x650a7354650a7354, 0x650a7354650a7354
-	dq	0x650a7354650a7354, 0x650a7354650a7354
-	dq	0x766a0abb766a0abb, 0x766a0abb766a0abb
-	dq	0x766a0abb766a0abb, 0x766a0abb766a0abb
-	dq	0x766a0abb766a0abb, 0x766a0abb766a0abb
-	dq	0x766a0abb766a0abb, 0x766a0abb766a0abb
-	dq	0x81c2c92e81c2c92e, 0x81c2c92e81c2c92e
-	dq	0x81c2c92e81c2c92e, 0x81c2c92e81c2c92e
-	dq	0x81c2c92e81c2c92e, 0x81c2c92e81c2c92e
-	dq	0x81c2c92e81c2c92e, 0x81c2c92e81c2c92e
-	dq	0x92722c8592722c85, 0x92722c8592722c85
-	dq	0x92722c8592722c85, 0x92722c8592722c85
-	dq	0x92722c8592722c85, 0x92722c8592722c85
-	dq	0x92722c8592722c85, 0x92722c8592722c85
-	dq	0xa2bfe8a1a2bfe8a1, 0xa2bfe8a1a2bfe8a1
-	dq	0xa2bfe8a1a2bfe8a1, 0xa2bfe8a1a2bfe8a1
-	dq	0xa2bfe8a1a2bfe8a1, 0xa2bfe8a1a2bfe8a1
-	dq	0xa2bfe8a1a2bfe8a1, 0xa2bfe8a1a2bfe8a1
-	dq	0xa81a664ba81a664b, 0xa81a664ba81a664b
-	dq	0xa81a664ba81a664b, 0xa81a664ba81a664b
-	dq	0xa81a664ba81a664b, 0xa81a664ba81a664b
-	dq	0xa81a664ba81a664b, 0xa81a664ba81a664b
-	dq	0xc24b8b70c24b8b70, 0xc24b8b70c24b8b70
-	dq	0xc24b8b70c24b8b70, 0xc24b8b70c24b8b70
-	dq	0xc24b8b70c24b8b70, 0xc24b8b70c24b8b70
-	dq	0xc24b8b70c24b8b70, 0xc24b8b70c24b8b70
-	dq	0xc76c51a3c76c51a3, 0xc76c51a3c76c51a3
-	dq	0xc76c51a3c76c51a3, 0xc76c51a3c76c51a3
-	dq	0xc76c51a3c76c51a3, 0xc76c51a3c76c51a3
-	dq	0xc76c51a3c76c51a3, 0xc76c51a3c76c51a3
-	dq	0xd192e819d192e819, 0xd192e819d192e819
-	dq	0xd192e819d192e819, 0xd192e819d192e819
-	dq	0xd192e819d192e819, 0xd192e819d192e819
-	dq	0xd192e819d192e819, 0xd192e819d192e819
-	dq	0xd6990624d6990624, 0xd6990624d6990624
-	dq	0xd6990624d6990624, 0xd6990624d6990624
-	dq	0xd6990624d6990624, 0xd6990624d6990624
-	dq	0xd6990624d6990624, 0xd6990624d6990624
-	dq	0xf40e3585f40e3585, 0xf40e3585f40e3585
-	dq	0xf40e3585f40e3585, 0xf40e3585f40e3585
-	dq	0xf40e3585f40e3585, 0xf40e3585f40e3585
-	dq	0xf40e3585f40e3585, 0xf40e3585f40e3585
-	dq	0x106aa070106aa070, 0x106aa070106aa070
-	dq	0x106aa070106aa070, 0x106aa070106aa070
-	dq	0x106aa070106aa070, 0x106aa070106aa070
-	dq	0x106aa070106aa070, 0x106aa070106aa070
-	dq	0x19a4c11619a4c116, 0x19a4c11619a4c116
-	dq	0x19a4c11619a4c116, 0x19a4c11619a4c116
-	dq	0x19a4c11619a4c116, 0x19a4c11619a4c116
-	dq	0x19a4c11619a4c116, 0x19a4c11619a4c116
-	dq	0x1e376c081e376c08, 0x1e376c081e376c08
-	dq	0x1e376c081e376c08, 0x1e376c081e376c08
-	dq	0x1e376c081e376c08, 0x1e376c081e376c08
-	dq	0x1e376c081e376c08, 0x1e376c081e376c08
-	dq	0x2748774c2748774c, 0x2748774c2748774c
-	dq	0x2748774c2748774c, 0x2748774c2748774c
-	dq	0x2748774c2748774c, 0x2748774c2748774c
-	dq	0x2748774c2748774c, 0x2748774c2748774c
-	dq	0x34b0bcb534b0bcb5, 0x34b0bcb534b0bcb5
-	dq	0x34b0bcb534b0bcb5, 0x34b0bcb534b0bcb5
-	dq	0x34b0bcb534b0bcb5, 0x34b0bcb534b0bcb5
-	dq	0x34b0bcb534b0bcb5, 0x34b0bcb534b0bcb5
-	dq	0x391c0cb3391c0cb3, 0x391c0cb3391c0cb3
-	dq	0x391c0cb3391c0cb3, 0x391c0cb3391c0cb3
-	dq	0x391c0cb3391c0cb3, 0x391c0cb3391c0cb3
-	dq	0x391c0cb3391c0cb3, 0x391c0cb3391c0cb3
-	dq	0x4ed8aa4a4ed8aa4a, 0x4ed8aa4a4ed8aa4a
-	dq	0x4ed8aa4a4ed8aa4a, 0x4ed8aa4a4ed8aa4a
-	dq	0x4ed8aa4a4ed8aa4a, 0x4ed8aa4a4ed8aa4a
-	dq	0x4ed8aa4a4ed8aa4a, 0x4ed8aa4a4ed8aa4a
-	dq	0x5b9cca4f5b9cca4f, 0x5b9cca4f5b9cca4f
-	dq	0x5b9cca4f5b9cca4f, 0x5b9cca4f5b9cca4f
-	dq	0x5b9cca4f5b9cca4f, 0x5b9cca4f5b9cca4f
-	dq	0x5b9cca4f5b9cca4f, 0x5b9cca4f5b9cca4f
-	dq	0x682e6ff3682e6ff3, 0x682e6ff3682e6ff3
-	dq	0x682e6ff3682e6ff3, 0x682e6ff3682e6ff3
-	dq	0x682e6ff3682e6ff3, 0x682e6ff3682e6ff3
-	dq	0x682e6ff3682e6ff3, 0x682e6ff3682e6ff3
-	dq	0x748f82ee748f82ee, 0x748f82ee748f82ee
-	dq	0x748f82ee748f82ee, 0x748f82ee748f82ee
-	dq	0x748f82ee748f82ee, 0x748f82ee748f82ee
-	dq	0x748f82ee748f82ee, 0x748f82ee748f82ee
-	dq	0x78a5636f78a5636f, 0x78a5636f78a5636f
-	dq	0x78a5636f78a5636f, 0x78a5636f78a5636f
-	dq	0x78a5636f78a5636f, 0x78a5636f78a5636f
-	dq	0x78a5636f78a5636f, 0x78a5636f78a5636f
-	dq	0x84c8781484c87814, 0x84c8781484c87814
-	dq	0x84c8781484c87814, 0x84c8781484c87814
-	dq	0x84c8781484c87814, 0x84c8781484c87814
-	dq	0x84c8781484c87814, 0x84c8781484c87814
-	dq	0x8cc702088cc70208, 0x8cc702088cc70208
-	dq	0x8cc702088cc70208, 0x8cc702088cc70208
-	dq	0x8cc702088cc70208, 0x8cc702088cc70208
-	dq	0x8cc702088cc70208, 0x8cc702088cc70208
-	dq	0x90befffa90befffa, 0x90befffa90befffa
-	dq	0x90befffa90befffa, 0x90befffa90befffa
-	dq	0x90befffa90befffa, 0x90befffa90befffa
-	dq	0x90befffa90befffa, 0x90befffa90befffa
-	dq	0xa4506ceba4506ceb, 0xa4506ceba4506ceb
-	dq	0xa4506ceba4506ceb, 0xa4506ceba4506ceb
-	dq	0xa4506ceba4506ceb, 0xa4506ceba4506ceb
-	dq	0xa4506ceba4506ceb, 0xa4506ceba4506ceb
-	dq	0xbef9a3f7bef9a3f7, 0xbef9a3f7bef9a3f7
-	dq	0xbef9a3f7bef9a3f7, 0xbef9a3f7bef9a3f7
-	dq	0xbef9a3f7bef9a3f7, 0xbef9a3f7bef9a3f7
-	dq	0xbef9a3f7bef9a3f7, 0xbef9a3f7bef9a3f7
-	dq	0xc67178f2c67178f2, 0xc67178f2c67178f2
-	dq	0xc67178f2c67178f2, 0xc67178f2c67178f2
-	dq	0xc67178f2c67178f2, 0xc67178f2c67178f2
-	dq	0xc67178f2c67178f2, 0xc67178f2c67178f2
+	dd	0x428a2f98
+	dd	0x71374491
+	dd	0xb5c0fbcf
+	dd	0xe9b5dba5
+	dd	0x3956c25b
+	dd	0x59f111f1
+	dd	0x923f82a4
+	dd	0xab1c5ed5
+	dd	0xd807aa98
+	dd	0x12835b01
+	dd	0x243185be
+	dd	0x550c7dc3
+	dd	0x72be5d74
+	dd	0x80deb1fe
+	dd	0x9bdc06a7
+	dd	0xc19bf174
+	dd	0xe49b69c1
+	dd	0xefbe4786
+	dd	0x0fc19dc6
+	dd	0x240ca1cc
+	dd	0x2de92c6f
+	dd	0x4a7484aa
+	dd	0x5cb0a9dc
+	dd	0x76f988da
+	dd	0x983e5152
+	dd	0xa831c66d
+	dd	0xb00327c8
+	dd	0xbf597fc7
+	dd	0xc6e00bf3
+	dd	0xd5a79147
+	dd	0x06ca6351
+	dd	0x14292967
+	dd	0x27b70a85
+	dd	0x2e1b2138
+	dd	0x4d2c6dfc
+	dd	0x53380d13
+	dd	0x650a7354
+	dd	0x766a0abb
+	dd	0x81c2c92e
+	dd	0x92722c85
+	dd	0xa2bfe8a1
+	dd	0xa81a664b
+	dd	0xc24b8b70
+	dd	0xc76c51a3
+	dd	0xd192e819
+	dd	0xd6990624
+	dd	0xf40e3585
+	dd	0x106aa070
+	dd	0x19a4c116
+	dd	0x1e376c08
+	dd	0x2748774c
+	dd	0x34b0bcb5
+	dd	0x391c0cb3
+	dd	0x4ed8aa4a
+	dd	0x5b9cca4f
+	dd	0x682e6ff3
+	dd	0x748f82ee
+	dd	0x78a5636f
+	dd	0x84c87814
+	dd	0x8cc70208
+	dd	0x90befffa
+	dd	0xa4506ceb
+	dd	0xbef9a3f7
+	dd	0xc67178f2
 
 
 PSHUFFLE_BYTE_FLIP_MASK: dq 0x0405060700010203, 0x0c0d0e0f08090a0b
-			 dq 0x0405060700010203, 0x0c0d0e0f08090a0b
-			 dq 0x0405060700010203, 0x0c0d0e0f08090a0b
-			 dq 0x0405060700010203, 0x0c0d0e0f08090a0b
 
-PSHUFFLE_TRANSPOSE16_MASK1: 	dq 0x0000000000000000
-				dq 0x0000000000000001
-				dq 0x0000000000000008
-				dq 0x0000000000000009
-				dq 0x0000000000000004
-				dq 0x0000000000000005
-				dq 0x000000000000000C
-				dq 0x000000000000000D
+PSHUFFLE_TRANSPOSE16_MASK1: 	db 0x0000000000000000
+				db 0x0000000000000001
+				db 0x0000000000000008
+				db 0x0000000000000009
+				db 0x0000000000000004
+				db 0x0000000000000005
+				db 0x000000000000000C
+				db 0x000000000000000D
 
-PSHUFFLE_TRANSPOSE16_MASK2: 	dq 0x0000000000000002
-				dq 0x0000000000000003
-				dq 0x000000000000000A
-				dq 0x000000000000000B
-				dq 0x0000000000000006
-				dq 0x0000000000000007
-				dq 0x000000000000000E
-				dq 0x000000000000000F
+PSHUFFLE_TRANSPOSE16_MASK2: 	db 0x0000000000000002
+				db 0x0000000000000003
+				db 0x000000000000000A
+				db 0x000000000000000B
+				db 0x0000000000000006
+				db 0x0000000000000007
+				db 0x000000000000000E
+				db 0x000000000000000F
 
 %else
 %ifidn __OUTPUT_FORMAT__, win64

--- a/sm3_mb/sm3_mb_x16_avx512.asm
+++ b/sm3_mb/sm3_mb_x16_avx512.asm
@@ -163,6 +163,8 @@ FIELD	_rsp,		8,	8
 %define %%t1 %18
 
 	; process top half (r0..r3) {a...d}
+	vmovdqa32 TMP2, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 TMP3, [PSHUFFLE_TRANSPOSE16_MASK2]
 	vshufps	%%t0, %%r0, %%r1, 0x44	; t0 = {b13 b12 a13 a12   b9  b8  a9  a8   b5 b4 a5 a4   b1 b0 a1 a0}
 	vshufps	%%r0, %%r0, %%r1, 0xEE	; r0 = {b15 b14 a15 a14   b11 b10 a11 a10  b7 b6 a7 a6   b3 b2 a3 a2}
 	vshufps	%%t1, %%r2, %%r3, 0x44	; t1 = {d13 d12 c13 c12   d9  d8  c9  c8   d5 d4 c5 c4   d1 d0 c1 c0}
@@ -206,44 +208,44 @@ FIELD	_rsp,		8,	8
 	vshufps	%%r12, %%r12, %%r14, 0xDD	; r12 = {p15 015 n15 m15   p11 011 n11 m11  p7 07 n7 m7   p3 03 n3 m3}
 	vshufps	%%r10, %%r10, %%t1,  0x88	; r10 = {p12 012 n12 m12   p8  08  n8  m8   p4 04 n4 m4   p0 00 n0 m0}
 
-	vmovdqa32 %%r14, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r14, TMP2
 	vpermi2q  %%r14, %%t0, %%r2		; r14 = {h8  g8  f8  e8   d8  c8  b8  a8   h0 g0 f0 e0	 d0 c0 b0 a0}
-	vmovdqa32 %%t1,  [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%t1,  TMP3
 	vpermi2q  %%t1,  %%t0, %%r2		; t1  = {h12 g12 f12 e12  d12 c12 b12 a12  h4 g4 f4 e4	 d4 c4 b4 a4}
 
-	vmovdqa32 %%r2, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r2, TMP2
 	vpermi2q  %%r2, %%r3, %%r7		; r2  = {h9  g9  f9  e9   d9  c9  b9  a9   h1 g1 f1 e1	 d1 c1 b1 a1}
-	vmovdqa32 %%t0, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%t0, TMP3
 	vpermi2q  %%t0, %%r3, %%r7		; t0  = {h13 g13 f13 e13  d13 c13 b13 a13  h5 g5 f5 e5	 d5 c5 b5 a5}
 
-	vmovdqa32 %%r3, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r3, TMP2
 	vpermi2q  %%r3, %%r1, %%r5		; r3  = {h10 g10 f10 e10  d10 c10 b10 a10  h2 g2 f2 e2	 d2 c2 b2 a2}
-	vmovdqa32 %%r7, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r7, TMP3
 	vpermi2q  %%r7, %%r1, %%r5		; r7  = {h14 g14 f14 e14  d14 c14 b14 a14  h6 g6 f6 e6	 d6 c6 b6 a6}
 
-	vmovdqa32 %%r1, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r1, TMP2
 	vpermi2q  %%r1, %%r0, %%r4		; r1  = {h11 g11 f11 e11  d11 c11 b11 a11  h3 g3 f3 e3	 d3 c3 b3 a3}
-	vmovdqa32 %%r5, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r5, TMP3
 	vpermi2q  %%r5, %%r0, %%r4		; r5  = {h15 g15 f15 e15  d15 c15 b15 a15  h7 g7 f7 e7	 d7 c7 b7 a7}
 
-	vmovdqa32 %%r0, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r0, TMP2
 	vpermi2q  %%r0, %%r6, %%r10		; r0 = {p8  o8  n8  m8   l8  k8  j8  i8   p0 o0 n0 m0	 l0 k0 j0 i0}
-	vmovdqa32 %%r4,  [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r4,  TMP3
 	vpermi2q  %%r4, %%r6, %%r10		; r4  = {p12 o12 n12 m12  l12 k12 j12 i12  p4 o4 n4 m4	 l4 k4 j4 i4}
 
-	vmovdqa32 %%r6, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r6, TMP2
 	vpermi2q  %%r6, %%r11, %%r15		; r6  = {p9  o9  n9  m9   l9  k9  j9  i9   p1 o1 n1 m1	 l1 k1 j1 i1}
-	vmovdqa32 %%r10, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r10, TMP3
 	vpermi2q  %%r10, %%r11, %%r15		; r10 = {p13 o13 n13 m13  l13 k13 j13 i13  p5 o5 n5 m5	 l5 k5 j5 i5}
 
-	vmovdqa32 %%r11, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r11, TMP2
 	vpermi2q  %%r11, %%r9, %%r13		; r11 = {p10 o10 n10 m10  l10 k10 j10 i10  p2 o2 n2 m2	 l2 k2 j2 i2}
-	vmovdqa32 %%r15, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r15, TMP3
 	vpermi2q  %%r15, %%r9, %%r13		; r15 = {p14 o14 n14 m14  l14 k14 j14 i14  p6 o6 n6 m6	 l6 k6 j6 i6}
 
-	vmovdqa32 %%r9, [PSHUFFLE_TRANSPOSE16_MASK1]
+	vmovdqa32 %%r9, TMP2
 	vpermi2q  %%r9, %%r8, %%r12		; r9  = {p11 o11 n11 m11  l11 k11 j11 i11  p3 o3 n3 m3	 l3 k3 j3 i3}
-	vmovdqa32 %%r13, [PSHUFFLE_TRANSPOSE16_MASK2]
+	vmovdqa32 %%r13, TMP3
 	vpermi2q  %%r13, %%r8, %%r12		; r13 = {p15 o15 n15 m15  l15 k15 j15 i15  p7 o7 n7 m7	 l7 k7 j7 i7}
 
 	;; At this point r8 and r12 can be used as scratch registers
@@ -326,7 +328,7 @@ FIELD	_rsp,		8,	8
 %define %%Y 	%2
 %define %%Z 	%3
 	; I < 16 return (X ^ Y ^ Z)
-	vmovups TMP0,%%X
+	vmovdqa32 TMP0,%%X
 	vpternlogd TMP0,%%Y,%%Z,0x96
 %endmacro
 
@@ -339,12 +341,10 @@ FIELD	_rsp,		8,	8
 %define %%X 	%1
 %define %%Y 	%2
 %define %%Z 	%3
-	; I > 16 return (x & y) | (x & z) | (y & z)
+	; I > 16 return (x & y) | (x & z) | (y & z) MAJ ABC
 	; Same as (x & y) | (z & (x | y))
-	vporq TMP0,%%X,%%Y
-	vpandq TMP0,%%Z
-	vpandq TMP1,%%X,%%Y
-	vporq TMP0,TMP1
+	vmovdqa32  TMP0, %%X
+	vpternlogd TMP0, %%Y, %%Z, 0xE8
 %endmacro
 
 
@@ -356,7 +356,7 @@ FIELD	_rsp,		8,	8
 %define %%Y 	%2
 %define %%Z 	%3
 	; I < 16 return (x ^ y ^ z)
-        vmovups TMP0,%%X
+        vmovdqa32 TMP0,%%X
         vpternlogd TMP0,%%Y,%%Z,0x96
 %endmacro
 
@@ -367,11 +367,11 @@ FIELD	_rsp,		8,	8
 %define %%Z 	%3
 
 	; I > 16 return (x & y) | ((~x) & z)
-	vpandq TMP0,%%X,%%Y
-	vpandnd TMP1,%%X,%%Z
-	vporq TMP0,TMP1
+	vmovdqa32 TMP0, %%X
+	vpternlogq TMP0, %%Y, %%Z, 0xCA
 %endmacro
 
+align 64
 ;; void sm3_mb_x16_avx512(SM3_MB_ARGS_X16, uint32_t size)
 ; arg 1 : pointer to input data
 ; arg 2 : size (in blocks) ;; assumed to be >= 1
@@ -387,18 +387,19 @@ sm3_mb_x16_avx512:
 	lea	TBL, [TABLE]
 
 	;; Initialize digests
-	vmovups	A, [DIGEST + 0*64] ; mov unsigned
-	vmovups	B, [DIGEST + 1*64]
-	vmovups	C, [DIGEST + 2*64]
-	vmovups	D, [DIGEST + 3*64]
-	vmovups	E, [DIGEST + 4*64]
-	vmovups	F, [DIGEST + 5*64]
-	vmovups	G, [DIGEST + 6*64]
-	vmovups	H, [DIGEST + 7*64]
+	vmovdqu32	A, [DIGEST + 0*64] ; mov unsigned
+	vmovdqu32	B, [DIGEST + 1*64]
+	vmovdqu32	C, [DIGEST + 2*64]
+	vmovdqu32	D, [DIGEST + 3*64]
+	vmovdqu32	E, [DIGEST + 4*64]
+	vmovdqu32	F, [DIGEST + 5*64]
+	vmovdqu32	G, [DIGEST + 6*64]
+	vmovdqu32	H, [DIGEST + 7*64]
 
 	xor IDX, IDX
 
 %assign cur_loop 0
+align 32
 lloop:
 	;; start message expand
 	;; Transpose input data
@@ -414,14 +415,14 @@ lloop:
 	;; stored B(i) to W(1)...W(15)
 	;; in zmm16....zmm31
 
-	vmovups	WB0,[inp0+IDX]
-	vmovups	WB1,[inp1+IDX]
-	vmovups	WB2,[inp2+IDX]
-	vmovups	WB3,[inp3+IDX]
-	vmovups	WB4,[inp4+IDX]
-	vmovups	WB5,[inp5+IDX]
-	vmovups	WB6,[inp6+IDX]
-	vmovups	WB7,[inp7+IDX]
+	vmovdqu32	WB0,[inp0+IDX]
+	vmovdqu32	WB1,[inp1+IDX]
+	vmovdqu32	WB2,[inp2+IDX]
+	vmovdqu32	WB3,[inp3+IDX]
+	vmovdqu32	WB4,[inp4+IDX]
+	vmovdqu32	WB5,[inp5+IDX]
+	vmovdqu32	WB6,[inp6+IDX]
+	vmovdqu32	WB7,[inp7+IDX]
 
 	mov	inp0, [IN + 8*8]
 	mov	inp1, [IN + 9*8]
@@ -432,14 +433,14 @@ lloop:
 	mov	inp6, [IN +14*8]
 	mov	inp7, [IN +15*8]
 
-	vmovups	WB8, [inp0+IDX]
-	vmovups	WB9, [inp1+IDX]
-	vmovups	WB10,[inp2+IDX]
-	vmovups	WB11,[inp3+IDX]
-	vmovups	WB12,[inp4+IDX]
-	vmovups	WB13,[inp5+IDX]
-	vmovups	WB14,[inp6+IDX]
-	vmovups	WB15,[inp7+IDX]
+	vmovdqu32	WB8, [inp0+IDX]
+	vmovdqu32	WB9, [inp1+IDX]
+	vmovdqu32	WB10,[inp2+IDX]
+	vmovdqu32	WB11,[inp3+IDX]
+	vmovdqu32	WB12,[inp4+IDX]
+	vmovdqu32	WB13,[inp5+IDX]
+	vmovdqu32	WB14,[inp6+IDX]
+	vmovdqu32	WB15,[inp7+IDX]
 
 	vmovdqa32	[rsp + _DIGEST_SAVE + 64*0], A
         vmovdqa32	[rsp + _DIGEST_SAVE + 64*1], B
@@ -456,7 +457,7 @@ lloop:
 	 TRANSPOSE16 WB0, WB1, WB2, WB3, WB4, WB5, WB6, WB7, WB8, WB9, WB10, WB11, WB12, WB13, WB14, WB15, TMP0, TMP1
 
 	; little endian to big endian
-	vmovdqa32 TMP0, [SHUF_MASK]
+	vbroadcasti32x4 TMP0, [SHUF_MASK]
 	vpshufb WB0,TMP0
 	vpshufb WB1,TMP0
 	vpshufb WB2,TMP0
@@ -485,8 +486,7 @@ lloop:
 	; SS1 = ((A <<< 12) + E + (T(j) <<< j)) <<< 7
 	; (T(j) <<< j) store in TBL
 	; SS1 store in TMP2
-	vmovdqa32 TMP2, [TBL + (I*64)]
-	vpaddd TMP2,E
+	vpaddd TMP2,E, [TBL + (I*4)]{1to16}
 
 	vpaddd TMP2,TMP0
 	vprold TMP2,7
@@ -520,17 +520,17 @@ lloop:
 	; G = F <<< 19
 	; F = E
 	; E = P(TT2)
-	vmovups D,C
+	vmovdqa32 D,C
 	vprold B,9
-	vmovups C,B
-	vmovups B,A
-	vmovups A,TMP3
-	vmovups H,G
+	vmovdqa32 C,B
+	vmovdqa32 B,A
+	vmovdqa32 A,TMP3
+	vmovdqa32 H,G
 	vprold F,19
-	vmovups G,F
-	vmovups F,E
+	vmovdqa32 G,F
+	vmovdqa32 F,E
 	P TMP2
-	vmovups E,TMP0
+	vmovdqa32 E,TMP0
 
 	;vprold B,9
 	;vprold F,19
@@ -572,8 +572,7 @@ lloop:
 	; SS1 = ((A <<< 12) + E + (T(j) <<< j)) <<< 7
 	; (T(j) <<< j) store in TBL
 	; SS1 store in TMP2
-	vmovdqa32 TMP2, [TBL + (I*64)]
-	vpaddd TMP2,E
+	vpaddd TMP2,E, [TBL + (I*4)] {1to16}
 
 	vpaddd TMP2,TMP0
 	vprold TMP2,7
@@ -606,17 +605,17 @@ lloop:
 	; G = F <<< 19
 	; F = E
 	; E = P(TT2)
-	vmovups D,C
+	vmovdqa32 D,C
 	vprold B,9
-	vmovups C,B
-	vmovups B,A
-	vmovups A,TMP3
-	vmovups H,G
+	vmovdqa32 C,B
+	vmovdqa32 B,A
+	vmovdqa32 A,TMP3
+	vmovdqa32 H,G
 	vprold F,19
-	vmovups G,F
-	vmovups F,E
+	vmovdqa32 G,F
+	vmovdqa32 F,E
 	P TMP2
-	vmovups E,TMP0
+	vmovdqa32 E,TMP0
 
 	%assign I (I+1)
 %endrep
@@ -650,8 +649,7 @@ lloop:
 	; SS1 = ((A <<< 12) + E + (T(j) <<< j)) <<< 7
 	; (T(j) <<< j) store in TBL
 	; SS1 store in TMP2
-	vmovdqa32 TMP2, [TBL + (I*64)]
-	vpaddd TMP2,E
+	vpaddd TMP2,E, [TBL+(I*4)]{1to16}
 
 	vpaddd TMP2,TMP0
 	vprold TMP2,7
@@ -684,17 +682,17 @@ lloop:
 	; G = F <<< 19
 	; F = E
 	; E = P(TT2)
-	vmovups D,C
+	vmovdqa32 D,C
 	vprold B,9
-	vmovups C,B
-	vmovups B,A
-	vmovups A,TMP3
-	vmovups H,G
+	vmovdqa32 C,B
+	vmovdqa32 B,A
+	vmovdqa32 A,TMP3
+	vmovdqa32 H,G
 	vprold F,19
-	vmovups G,F
-	vmovups F,E
+	vmovdqa32 G,F
+	vmovdqa32 F,E
 	P TMP2
-	vmovups E,TMP0
+	vmovdqa32 E,TMP0
 
 	%assign I (I+1)
 %endrep
@@ -710,32 +708,25 @@ lloop:
 
 	%assign cur_loop cur_loop+1
 	sub 	SIZE, 1
-	je	last_loop
-
-	jmp	lloop
+	jnz	lloop
 
 
 last_loop:
 
-%assign I 0
-%rep 8
-        mov    inp0, [IN + (2*I)*8]
-        mov    inp1, [IN + (2*I +1)*8]
-        add    inp0, IDX
-        add    inp1, IDX
-        mov    [IN + (2*I)*8], inp0
-        mov    [IN + (2*I+1)*8], inp1
-%assign I (I+1)
-%endrep
+	vpbroadcastq	TMP1, IDX
+	vpaddq	TMP0, TMP1, [IN]
+	vpaddq	TMP1, TMP1, [IN+64]
+	vmovdqu32 [IN], TMP0
+	vmovdqu32 [IN+64], TMP1
 	; Write out digest
-	vmovups	[DIGEST + 0*64], A
-	vmovups	[DIGEST + 1*64], B
-	vmovups	[DIGEST + 2*64], C
-	vmovups	[DIGEST + 3*64], D
-	vmovups	[DIGEST + 4*64], E
-	vmovups	[DIGEST + 5*64], F
-	vmovups	[DIGEST + 6*64], G
-	vmovups	[DIGEST + 7*64], H
+	vmovdqu32	[DIGEST + 0*64], A
+	vmovdqu32	[DIGEST + 1*64], B
+	vmovdqu32	[DIGEST + 2*64], C
+	vmovdqu32	[DIGEST + 3*64], D
+	vmovdqu32	[DIGEST + 4*64], E
+	vmovdqu32	[DIGEST + 5*64], F
+	vmovdqu32	[DIGEST + 6*64], G
+	vmovdqu32	[DIGEST + 7*64], H
 
 
         mov     rsp, [rsp + _rsp]
@@ -745,262 +736,70 @@ last_loop:
 section .data
 align 64
 TABLE:
-	dq 0x79cc451979cc4519,0x79cc451979cc4519
-	dq 0x79cc451979cc4519,0x79cc451979cc4519
-	dq 0x79cc451979cc4519,0x79cc451979cc4519
-	dq 0x79cc451979cc4519,0x79cc451979cc4519
-	dq 0xf3988a32f3988a32,0xf3988a32f3988a32
-	dq 0xf3988a32f3988a32,0xf3988a32f3988a32
-	dq 0xf3988a32f3988a32,0xf3988a32f3988a32
-	dq 0xf3988a32f3988a32,0xf3988a32f3988a32
-	dq 0xe7311465e7311465,0xe7311465e7311465
-	dq 0xe7311465e7311465,0xe7311465e7311465
-	dq 0xe7311465e7311465,0xe7311465e7311465
-	dq 0xe7311465e7311465,0xe7311465e7311465
-	dq 0xce6228cbce6228cb,0xce6228cbce6228cb
-	dq 0xce6228cbce6228cb,0xce6228cbce6228cb
-	dq 0xce6228cbce6228cb,0xce6228cbce6228cb
-	dq 0xce6228cbce6228cb,0xce6228cbce6228cb
-	dq 0x9cc451979cc45197,0x9cc451979cc45197
-	dq 0x9cc451979cc45197,0x9cc451979cc45197
-	dq 0x9cc451979cc45197,0x9cc451979cc45197
-	dq 0x9cc451979cc45197,0x9cc451979cc45197
-	dq 0x3988a32f3988a32f,0x3988a32f3988a32f
-	dq 0x3988a32f3988a32f,0x3988a32f3988a32f
-	dq 0x3988a32f3988a32f,0x3988a32f3988a32f
-	dq 0x3988a32f3988a32f,0x3988a32f3988a32f
-	dq 0x7311465e7311465e,0x7311465e7311465e
-	dq 0x7311465e7311465e,0x7311465e7311465e
-	dq 0x7311465e7311465e,0x7311465e7311465e
-	dq 0x7311465e7311465e,0x7311465e7311465e
-	dq 0xe6228cbce6228cbc,0xe6228cbce6228cbc
-	dq 0xe6228cbce6228cbc,0xe6228cbce6228cbc
-	dq 0xe6228cbce6228cbc,0xe6228cbce6228cbc
-	dq 0xe6228cbce6228cbc,0xe6228cbce6228cbc
-	dq 0xcc451979cc451979,0xcc451979cc451979
-	dq 0xcc451979cc451979,0xcc451979cc451979
-	dq 0xcc451979cc451979,0xcc451979cc451979
-	dq 0xcc451979cc451979,0xcc451979cc451979
-	dq 0x988a32f3988a32f3,0x988a32f3988a32f3
-	dq 0x988a32f3988a32f3,0x988a32f3988a32f3
-	dq 0x988a32f3988a32f3,0x988a32f3988a32f3
-	dq 0x988a32f3988a32f3,0x988a32f3988a32f3
-	dq 0x311465e7311465e7,0x311465e7311465e7
-	dq 0x311465e7311465e7,0x311465e7311465e7
-	dq 0x311465e7311465e7,0x311465e7311465e7
-	dq 0x311465e7311465e7,0x311465e7311465e7
-	dq 0x6228cbce6228cbce,0x6228cbce6228cbce
-	dq 0x6228cbce6228cbce,0x6228cbce6228cbce
-	dq 0x6228cbce6228cbce,0x6228cbce6228cbce
-	dq 0x6228cbce6228cbce,0x6228cbce6228cbce
-	dq 0xc451979cc451979c,0xc451979cc451979c
-	dq 0xc451979cc451979c,0xc451979cc451979c
-	dq 0xc451979cc451979c,0xc451979cc451979c
-	dq 0xc451979cc451979c,0xc451979cc451979c
-	dq 0x88a32f3988a32f39,0x88a32f3988a32f39
-	dq 0x88a32f3988a32f39,0x88a32f3988a32f39
-	dq 0x88a32f3988a32f39,0x88a32f3988a32f39
-	dq 0x88a32f3988a32f39,0x88a32f3988a32f39
-	dq 0x11465e7311465e73,0x11465e7311465e73
-	dq 0x11465e7311465e73,0x11465e7311465e73
-	dq 0x11465e7311465e73,0x11465e7311465e73
-	dq 0x11465e7311465e73,0x11465e7311465e73
-	dq 0x228cbce6228cbce6,0x228cbce6228cbce6
-	dq 0x228cbce6228cbce6,0x228cbce6228cbce6
-	dq 0x228cbce6228cbce6,0x228cbce6228cbce6
-	dq 0x228cbce6228cbce6,0x228cbce6228cbce6
-	dq 0x9d8a7a879d8a7a87,0x9d8a7a879d8a7a87
-	dq 0x9d8a7a879d8a7a87,0x9d8a7a879d8a7a87
-	dq 0x9d8a7a879d8a7a87,0x9d8a7a879d8a7a87
-	dq 0x9d8a7a879d8a7a87,0x9d8a7a879d8a7a87
-	dq 0x3b14f50f3b14f50f,0x3b14f50f3b14f50f
-	dq 0x3b14f50f3b14f50f,0x3b14f50f3b14f50f
-	dq 0x3b14f50f3b14f50f,0x3b14f50f3b14f50f
-	dq 0x3b14f50f3b14f50f,0x3b14f50f3b14f50f
-	dq 0x7629ea1e7629ea1e,0x7629ea1e7629ea1e
-	dq 0x7629ea1e7629ea1e,0x7629ea1e7629ea1e
-	dq 0x7629ea1e7629ea1e,0x7629ea1e7629ea1e
-	dq 0x7629ea1e7629ea1e,0x7629ea1e7629ea1e
-	dq 0xec53d43cec53d43c,0xec53d43cec53d43c
-	dq 0xec53d43cec53d43c,0xec53d43cec53d43c
-	dq 0xec53d43cec53d43c,0xec53d43cec53d43c
-	dq 0xec53d43cec53d43c,0xec53d43cec53d43c
-	dq 0xd8a7a879d8a7a879,0xd8a7a879d8a7a879
-	dq 0xd8a7a879d8a7a879,0xd8a7a879d8a7a879
-	dq 0xd8a7a879d8a7a879,0xd8a7a879d8a7a879
-	dq 0xd8a7a879d8a7a879,0xd8a7a879d8a7a879
-	dq 0xb14f50f3b14f50f3,0xb14f50f3b14f50f3
-	dq 0xb14f50f3b14f50f3,0xb14f50f3b14f50f3
-	dq 0xb14f50f3b14f50f3,0xb14f50f3b14f50f3
-	dq 0xb14f50f3b14f50f3,0xb14f50f3b14f50f3
-	dq 0x629ea1e7629ea1e7,0x629ea1e7629ea1e7
-	dq 0x629ea1e7629ea1e7,0x629ea1e7629ea1e7
-	dq 0x629ea1e7629ea1e7,0x629ea1e7629ea1e7
-	dq 0x629ea1e7629ea1e7,0x629ea1e7629ea1e7
-	dq 0xc53d43cec53d43ce,0xc53d43cec53d43ce
-	dq 0xc53d43cec53d43ce,0xc53d43cec53d43ce
-	dq 0xc53d43cec53d43ce,0xc53d43cec53d43ce
-	dq 0xc53d43cec53d43ce,0xc53d43cec53d43ce
-	dq 0x8a7a879d8a7a879d,0x8a7a879d8a7a879d
-	dq 0x8a7a879d8a7a879d,0x8a7a879d8a7a879d
-	dq 0x8a7a879d8a7a879d,0x8a7a879d8a7a879d
-	dq 0x8a7a879d8a7a879d,0x8a7a879d8a7a879d
-	dq 0x14f50f3b14f50f3b,0x14f50f3b14f50f3b
-	dq 0x14f50f3b14f50f3b,0x14f50f3b14f50f3b
-	dq 0x14f50f3b14f50f3b,0x14f50f3b14f50f3b
-	dq 0x14f50f3b14f50f3b,0x14f50f3b14f50f3b
-	dq 0x29ea1e7629ea1e76,0x29ea1e7629ea1e76
-	dq 0x29ea1e7629ea1e76,0x29ea1e7629ea1e76
-	dq 0x29ea1e7629ea1e76,0x29ea1e7629ea1e76
-	dq 0x29ea1e7629ea1e76,0x29ea1e7629ea1e76
-	dq 0x53d43cec53d43cec,0x53d43cec53d43cec
-	dq 0x53d43cec53d43cec,0x53d43cec53d43cec
-	dq 0x53d43cec53d43cec,0x53d43cec53d43cec
-	dq 0x53d43cec53d43cec,0x53d43cec53d43cec
-	dq 0xa7a879d8a7a879d8,0xa7a879d8a7a879d8
-	dq 0xa7a879d8a7a879d8,0xa7a879d8a7a879d8
-	dq 0xa7a879d8a7a879d8,0xa7a879d8a7a879d8
-	dq 0xa7a879d8a7a879d8,0xa7a879d8a7a879d8
-	dq 0x4f50f3b14f50f3b1,0x4f50f3b14f50f3b1
-	dq 0x4f50f3b14f50f3b1,0x4f50f3b14f50f3b1
-	dq 0x4f50f3b14f50f3b1,0x4f50f3b14f50f3b1
-	dq 0x4f50f3b14f50f3b1,0x4f50f3b14f50f3b1
-	dq 0x9ea1e7629ea1e762,0x9ea1e7629ea1e762
-	dq 0x9ea1e7629ea1e762,0x9ea1e7629ea1e762
-	dq 0x9ea1e7629ea1e762,0x9ea1e7629ea1e762
-	dq 0x9ea1e7629ea1e762,0x9ea1e7629ea1e762
-	dq 0x3d43cec53d43cec5,0x3d43cec53d43cec5
-	dq 0x3d43cec53d43cec5,0x3d43cec53d43cec5
-	dq 0x3d43cec53d43cec5,0x3d43cec53d43cec5
-	dq 0x3d43cec53d43cec5,0x3d43cec53d43cec5
-	dq 0x7a879d8a7a879d8a,0x7a879d8a7a879d8a
-	dq 0x7a879d8a7a879d8a,0x7a879d8a7a879d8a
-	dq 0x7a879d8a7a879d8a,0x7a879d8a7a879d8a
-	dq 0x7a879d8a7a879d8a,0x7a879d8a7a879d8a
-	dq 0xf50f3b14f50f3b14,0xf50f3b14f50f3b14
-	dq 0xf50f3b14f50f3b14,0xf50f3b14f50f3b14
-	dq 0xf50f3b14f50f3b14,0xf50f3b14f50f3b14
-	dq 0xf50f3b14f50f3b14,0xf50f3b14f50f3b14
-	dq 0xea1e7629ea1e7629,0xea1e7629ea1e7629
-	dq 0xea1e7629ea1e7629,0xea1e7629ea1e7629
-	dq 0xea1e7629ea1e7629,0xea1e7629ea1e7629
-	dq 0xea1e7629ea1e7629,0xea1e7629ea1e7629
-	dq 0xd43cec53d43cec53,0xd43cec53d43cec53
-	dq 0xd43cec53d43cec53,0xd43cec53d43cec53
-	dq 0xd43cec53d43cec53,0xd43cec53d43cec53
-	dq 0xd43cec53d43cec53,0xd43cec53d43cec53
-	dq 0xa879d8a7a879d8a7,0xa879d8a7a879d8a7
-	dq 0xa879d8a7a879d8a7,0xa879d8a7a879d8a7
-	dq 0xa879d8a7a879d8a7,0xa879d8a7a879d8a7
-	dq 0xa879d8a7a879d8a7,0xa879d8a7a879d8a7
-	dq 0x50f3b14f50f3b14f,0x50f3b14f50f3b14f
-	dq 0x50f3b14f50f3b14f,0x50f3b14f50f3b14f
-	dq 0x50f3b14f50f3b14f,0x50f3b14f50f3b14f
-	dq 0x50f3b14f50f3b14f,0x50f3b14f50f3b14f
-	dq 0xa1e7629ea1e7629e,0xa1e7629ea1e7629e
-	dq 0xa1e7629ea1e7629e,0xa1e7629ea1e7629e
-	dq 0xa1e7629ea1e7629e,0xa1e7629ea1e7629e
-	dq 0xa1e7629ea1e7629e,0xa1e7629ea1e7629e
-	dq 0x43cec53d43cec53d,0x43cec53d43cec53d
-	dq 0x43cec53d43cec53d,0x43cec53d43cec53d
-	dq 0x43cec53d43cec53d,0x43cec53d43cec53d
-	dq 0x43cec53d43cec53d,0x43cec53d43cec53d
-	dq 0x879d8a7a879d8a7a,0x879d8a7a879d8a7a
-	dq 0x879d8a7a879d8a7a,0x879d8a7a879d8a7a
-	dq 0x879d8a7a879d8a7a,0x879d8a7a879d8a7a
-	dq 0x879d8a7a879d8a7a,0x879d8a7a879d8a7a
-	dq 0x0f3b14f50f3b14f5,0x0f3b14f50f3b14f5
-	dq 0x0f3b14f50f3b14f5,0x0f3b14f50f3b14f5
-	dq 0x0f3b14f50f3b14f5,0x0f3b14f50f3b14f5
-	dq 0x0f3b14f50f3b14f5,0x0f3b14f50f3b14f5
-	dq 0x1e7629ea1e7629ea,0x1e7629ea1e7629ea
-	dq 0x1e7629ea1e7629ea,0x1e7629ea1e7629ea
-	dq 0x1e7629ea1e7629ea,0x1e7629ea1e7629ea
-	dq 0x1e7629ea1e7629ea,0x1e7629ea1e7629ea
-	dq 0x3cec53d43cec53d4,0x3cec53d43cec53d4
-	dq 0x3cec53d43cec53d4,0x3cec53d43cec53d4
-	dq 0x3cec53d43cec53d4,0x3cec53d43cec53d4
-	dq 0x3cec53d43cec53d4,0x3cec53d43cec53d4
-	dq 0x79d8a7a879d8a7a8,0x79d8a7a879d8a7a8
-	dq 0x79d8a7a879d8a7a8,0x79d8a7a879d8a7a8
-	dq 0x79d8a7a879d8a7a8,0x79d8a7a879d8a7a8
-	dq 0x79d8a7a879d8a7a8,0x79d8a7a879d8a7a8
-	dq 0xf3b14f50f3b14f50,0xf3b14f50f3b14f50
-	dq 0xf3b14f50f3b14f50,0xf3b14f50f3b14f50
-	dq 0xf3b14f50f3b14f50,0xf3b14f50f3b14f50
-	dq 0xf3b14f50f3b14f50,0xf3b14f50f3b14f50
-	dq 0xe7629ea1e7629ea1,0xe7629ea1e7629ea1
-	dq 0xe7629ea1e7629ea1,0xe7629ea1e7629ea1
-	dq 0xe7629ea1e7629ea1,0xe7629ea1e7629ea1
-	dq 0xe7629ea1e7629ea1,0xe7629ea1e7629ea1
-	dq 0xcec53d43cec53d43,0xcec53d43cec53d43
-	dq 0xcec53d43cec53d43,0xcec53d43cec53d43
-	dq 0xcec53d43cec53d43,0xcec53d43cec53d43
-	dq 0xcec53d43cec53d43,0xcec53d43cec53d43
-	dq 0x9d8a7a879d8a7a87,0x9d8a7a879d8a7a87
-	dq 0x9d8a7a879d8a7a87,0x9d8a7a879d8a7a87
-	dq 0x9d8a7a879d8a7a87,0x9d8a7a879d8a7a87
-	dq 0x9d8a7a879d8a7a87,0x9d8a7a879d8a7a87
-	dq 0x3b14f50f3b14f50f,0x3b14f50f3b14f50f
-	dq 0x3b14f50f3b14f50f,0x3b14f50f3b14f50f
-	dq 0x3b14f50f3b14f50f,0x3b14f50f3b14f50f
-	dq 0x3b14f50f3b14f50f,0x3b14f50f3b14f50f
-	dq 0x7629ea1e7629ea1e,0x7629ea1e7629ea1e
-	dq 0x7629ea1e7629ea1e,0x7629ea1e7629ea1e
-	dq 0x7629ea1e7629ea1e,0x7629ea1e7629ea1e
-	dq 0x7629ea1e7629ea1e,0x7629ea1e7629ea1e
-	dq 0xec53d43cec53d43c,0xec53d43cec53d43c
-	dq 0xec53d43cec53d43c,0xec53d43cec53d43c
-	dq 0xec53d43cec53d43c,0xec53d43cec53d43c
-	dq 0xec53d43cec53d43c,0xec53d43cec53d43c
-	dq 0xd8a7a879d8a7a879,0xd8a7a879d8a7a879
-	dq 0xd8a7a879d8a7a879,0xd8a7a879d8a7a879
-	dq 0xd8a7a879d8a7a879,0xd8a7a879d8a7a879
-	dq 0xd8a7a879d8a7a879,0xd8a7a879d8a7a879
-	dq 0xb14f50f3b14f50f3,0xb14f50f3b14f50f3
-	dq 0xb14f50f3b14f50f3,0xb14f50f3b14f50f3
-	dq 0xb14f50f3b14f50f3,0xb14f50f3b14f50f3
-	dq 0xb14f50f3b14f50f3,0xb14f50f3b14f50f3
-	dq 0x629ea1e7629ea1e7,0x629ea1e7629ea1e7
-	dq 0x629ea1e7629ea1e7,0x629ea1e7629ea1e7
-	dq 0x629ea1e7629ea1e7,0x629ea1e7629ea1e7
-	dq 0x629ea1e7629ea1e7,0x629ea1e7629ea1e7
-	dq 0xc53d43cec53d43ce,0xc53d43cec53d43ce
-	dq 0xc53d43cec53d43ce,0xc53d43cec53d43ce
-	dq 0xc53d43cec53d43ce,0xc53d43cec53d43ce
-	dq 0xc53d43cec53d43ce,0xc53d43cec53d43ce
-	dq 0x8a7a879d8a7a879d,0x8a7a879d8a7a879d
-	dq 0x8a7a879d8a7a879d,0x8a7a879d8a7a879d
-	dq 0x8a7a879d8a7a879d,0x8a7a879d8a7a879d
-	dq 0x8a7a879d8a7a879d,0x8a7a879d8a7a879d
-	dq 0x14f50f3b14f50f3b,0x14f50f3b14f50f3b
-	dq 0x14f50f3b14f50f3b,0x14f50f3b14f50f3b
-	dq 0x14f50f3b14f50f3b,0x14f50f3b14f50f3b
-	dq 0x14f50f3b14f50f3b,0x14f50f3b14f50f3b
-	dq 0x29ea1e7629ea1e76,0x29ea1e7629ea1e76
-	dq 0x29ea1e7629ea1e76,0x29ea1e7629ea1e76
-	dq 0x29ea1e7629ea1e76,0x29ea1e7629ea1e76
-	dq 0x29ea1e7629ea1e76,0x29ea1e7629ea1e76
-	dq 0x53d43cec53d43cec,0x53d43cec53d43cec
-	dq 0x53d43cec53d43cec,0x53d43cec53d43cec
-	dq 0x53d43cec53d43cec,0x53d43cec53d43cec
-	dq 0x53d43cec53d43cec,0x53d43cec53d43cec
-	dq 0xa7a879d8a7a879d8,0xa7a879d8a7a879d8
-	dq 0xa7a879d8a7a879d8,0xa7a879d8a7a879d8
-	dq 0xa7a879d8a7a879d8,0xa7a879d8a7a879d8
-	dq 0xa7a879d8a7a879d8,0xa7a879d8a7a879d8
-	dq 0x4f50f3b14f50f3b1,0x4f50f3b14f50f3b1
-	dq 0x4f50f3b14f50f3b1,0x4f50f3b14f50f3b1
-	dq 0x4f50f3b14f50f3b1,0x4f50f3b14f50f3b1
-	dq 0x4f50f3b14f50f3b1,0x4f50f3b14f50f3b1
-	dq 0x9ea1e7629ea1e762,0x9ea1e7629ea1e762
-	dq 0x9ea1e7629ea1e762,0x9ea1e7629ea1e762
-	dq 0x9ea1e7629ea1e762,0x9ea1e7629ea1e762
-	dq 0x9ea1e7629ea1e762,0x9ea1e7629ea1e762
-	dq 0x3d43cec53d43cec5,0x3d43cec53d43cec5
-	dq 0x3d43cec53d43cec5,0x3d43cec53d43cec5
-	dq 0x3d43cec53d43cec5,0x3d43cec53d43cec5
-	dq 0x3d43cec53d43cec5,0x3d43cec53d43cec5
+	dd 0x79cc4519
+	dd 0xf3988a32
+	dd 0xe7311465
+	dd 0xce6228cb
+	dd 0x9cc45197
+	dd 0x3988a32f
+	dd 0x7311465e
+	dd 0xe6228cbc
+	dd 0xcc451979
+	dd 0x988a32f3
+	dd 0x311465e7
+	dd 0x6228cbce
+	dd 0xc451979c
+	dd 0x88a32f39
+	dd 0x11465e73
+	dd 0x228cbce6
+	dd 0x9d8a7a87
+	dd 0x3b14f50f
+	dd 0x7629ea1e
+	dd 0xec53d43c
+	dd 0xd8a7a879
+	dd 0xb14f50f3
+	dd 0x629ea1e7
+	dd 0xc53d43ce
+	dd 0x8a7a879d
+	dd 0x14f50f3b
+	dd 0x29ea1e76
+	dd 0x53d43cec
+	dd 0xa7a879d8
+	dd 0x4f50f3b1
+	dd 0x9ea1e762
+	dd 0x3d43cec5
+	dd 0x7a879d8a
+	dd 0xf50f3b14
+	dd 0xea1e7629
+	dd 0xd43cec53
+	dd 0xa879d8a7
+	dd 0x50f3b14f
+	dd 0xa1e7629e
+	dd 0x43cec53d
+	dd 0x879d8a7a
+	dd 0x0f3b14f5
+	dd 0x1e7629ea
+	dd 0x3cec53d4
+	dd 0x79d8a7a8
+	dd 0xf3b14f50
+	dd 0xe7629ea1
+	dd 0xcec53d43
+	dd 0x9d8a7a87
+	dd 0x3b14f50f
+	dd 0x7629ea1e
+	dd 0xec53d43c
+	dd 0xd8a7a879
+	dd 0xb14f50f3
+	dd 0x629ea1e7
+	dd 0xc53d43ce
+	dd 0x8a7a879d
+	dd 0x14f50f3b
+	dd 0x29ea1e76
+	dd 0x53d43cec
+	dd 0xa7a879d8
+	dd 0x4f50f3b1
+	dd 0x9ea1e762
+	dd 0x3d43cec5
 
 
 
@@ -1023,9 +822,6 @@ PSHUFFLE_TRANSPOSE16_MASK2: 	dq 0x0000000000000002
 				dq 0x000000000000000F
 
 SHUF_MASK:			dq 0x0405060700010203,0x0c0d0e0f08090a0b
-				dq 0x0405060700010203,0x0c0d0e0f08090a0b
-				dq 0x0405060700010203,0x0c0d0e0f08090a0b
-				dq 0x0405060700010203,0x0c0d0e0f08090a0b
 
 %else
 %ifidn __OUTPUT_FORMAT__, win64


### PR DESCRIPTION
Hi. I've tried to make a minimal version of my patch for using the AVX512 embedded broadcast feature.
I've kept only the embedded broadcast, using SIMD instructions to update the data pointers instead of the unrolled scalar code and loop alignment to maximize uop-cache utilization. 
On SM3_MB i've also switched 2 macros to use VPTERNLOG instead of a sequence of separate logical instructions.
passes `make tests' on my PC (Linux and Rocketlake CPU). 
Sorry for the new pull request, but i haven't found a way to edit the other pull-request under git to only apply parts of my changes.