### PR TITLE
fix redefined warning on aarch64 when using autoconf 2.71

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -123,7 +123,11 @@ EXTRA_DIST += tools/yasm-filter.sh tools/nasm-filter.sh
 EXTRA_DIST += tools/yasm-cet-filter.sh tools/nasm-cet-filter.sh
 
 AM_CFLAGS = ${my_CFLAGS} ${INCLUDE} $(src_include) ${D}
+if CPU_AARCH64
+AM_CCASFLAGS = ${yasm_args} ${INCLUDE} $(src_include) ${D}
+else
 AM_CCASFLAGS = ${yasm_args} ${INCLUDE} $(src_include) ${DEFS} ${D}
+endif
 
 .asm.s:
 	@echo "  MKTMP   " $@;


### PR DESCRIPTION
Fix compilation warning: [issues #124](https://github.com/intel/isa-l_crypto/issues/124)