### PR TITLE
Changed nmake to build against MSVCRT (/MD, /MDd)

### DIFF
--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -267,8 +267,8 @@ objs = \
 INCLUDES  = -I./ -Isha1_mb/ -Isha256_mb/ -Isha512_mb/ -Imd5_mb/ -Imh_sha1/ -Imh_sha1_murmur3_x64_128/ -Imh_sha256/ -Irolling_hash/ -Ism3_mb/ -Iaes/ -Iinclude/ -Iintel-ipsec-mb/lib
 # Modern asm feature level, consider upgrading nasm before decreasing feature_level
 FEAT_FLAGS = -DAS_FEATURE_LEVEL=10
-CFLAGS_REL = -O2 -DNDEBUG /Z7 /Gy /ZH:SHA_256 /guard:cf
-CFLAGS_DBG = -Od -DDEBUG /Z7
+CFLAGS_REL = -O2 -DNDEBUG /Z7 /MD /Gy /ZH:SHA_256 /guard:cf
+CFLAGS_DBG = -Od -DDEBUG /Z7 /MDd
 
 !if "$(CONFIG)" == "DEBUG"
 CFLAGS=$(CFLAGS_DBG)


### PR DESCRIPTION
* When the runtime type option is omitted, VC++ builds object files with a `LIBCMT` directive, which is a thread-safe CRT statically linked runtime library.
* This change adds explicit release and debug dynamic CRT options into build configurations.