### PR TITLE
add riscv64 support and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,18 @@ jobs:
         uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028 # v1.5.1
       - name: Build
         run: nmake -f Makefile.nmake
+
+  run_tests_linux-riscv64-v:
+    needs: check_format
+    runs-on: run_tests_linux-riscv64-v
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - name: Build
+        run: |
+          ./autogen.sh
+          ./configure
+          bash -c 'make -j $(nproc)'
+      - name: Run tests
+        run: bash tools/test_checks.sh
+      - name: Run extended tests
+        run: bash tools/test_extended.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,7 @@ lsrc32=
 lsrc_x86_64=
 lsrc_x86_32=
 lsrc_aarch64=
+lsrc_riscv64=
 lsrc_base_aliases=
 unit_tests32=
 perf_tests32=
@@ -73,6 +74,10 @@ if CPU_AARCH64
 libisal_crypto_la_SOURCES += ${lsrc_aarch64}
 endif
 
+if CPU_RISCV64
+libisal_crypto_la_SOURCES += ${lsrc_riscv64}
+endif
+
 if CPU_UNDEFINED
 libisal_crypto_la_SOURCES += ${lsrc_base_aliases}
 endif
@@ -117,6 +122,9 @@ endif
 if CPU_AARCH64
   as_filter = $(CC) -D__ASSEMBLY__
 endif
+if CPU_RISCV64
+  as_filter = $(CC) -D__ASSEMBLY__
+endif
 CCAS = $(as_filter)
 EXTRA_DIST += tools/nasm-filter.sh
 EXTRA_DIST += tools/nasm-cet-filter.sh
@@ -126,6 +134,9 @@ if CPU_AARCH64
 AM_CCASFLAGS = ${asm_args} ${INCLUDE} $(src_include) ${D}
 else
 AM_CCASFLAGS = ${asm_args} ${INCLUDE} $(src_include) ${DEFS} ${D}
+endif
+if CPU_RISCV64
+AM_CCASFLAGS = ${asm_args} ${INCLUDE} $(src_include) ${D}
 endif
 
 .asm.s:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ aarch64:
     * ./configure --disable-sve2
     * make -f Makefile.unx DEFINES+=-DNO_SVE2=1
 
+RISC-V 64 and other:
+* Compiler: Portable base functions are available that build with most C compilers.
+
 ### Autotools
 To build and install the library with autotools it is usually sufficient to run:
 

--- a/Release_notes.txt
+++ b/Release_notes.txt
@@ -83,6 +83,8 @@ v2.26
 
 * Added SM3-NI AVX2 implementation.
 
+* Added support for RISC-V 64 architecture.
+
 v2.25
 
 * Added new API including parameter checking (starting with isal_ prefix).

--- a/configure.ac
+++ b/configure.ac
@@ -29,10 +29,12 @@ AS_CASE([$host_cpu],
   [i?86], [CPU="x86_32"],
   [aarch64], [CPU="aarch64"],
   [arm64], [CPU="aarch64"],
+  [riscv64], [CPU="riscv64"],
 )
 AM_CONDITIONAL([CPU_X86_64], [test "$CPU" = "x86_64"])
 AM_CONDITIONAL([CPU_X86_32], [test "$CPU" = "x86_32"])
 AM_CONDITIONAL([CPU_AARCH64], [test "$CPU" = "aarch64"])
+AM_CONDITIONAL([CPU_RISCV64], [test "$CPU" = "riscv64"])
 AM_CONDITIONAL([CPU_UNDEFINED], [test "x$CPU" = "x"])
 AM_CONDITIONAL([SAFE_PARAM], [test x"$SAFE_PARAM" = x"yes"])
 

--- a/fips/Makefile.am
+++ b/fips/Makefile.am
@@ -30,9 +30,8 @@
 src_include     += -I $(srcdir)/fips
 extern_hdrs     += include/isal_crypto_api.h include/aes_xts.h include/aes_keyexp.h include/sha1_mb.h include/sha256_mb.h
 
-lsrc_x86_64     += fips/self_tests.c
-lsrc_aarch64    += fips/self_tests_generic.c
-lsrc            += fips/aes_self_tests.c
+lsrc_x86_64     += fips/self_tests.c fips/aes_self_tests.c
+lsrc_aarch64    += fips/self_tests_generic.c fips/aes_self_tests.c
 lsrc            += fips/sha_self_tests.c
 
 lsrc_x86_64     += fips/asm_self_tests.asm

--- a/fips/Makefile.am
+++ b/fips/Makefile.am
@@ -32,6 +32,7 @@ extern_hdrs     += include/isal_crypto_api.h include/aes_xts.h include/aes_keyex
 
 lsrc_x86_64     += fips/self_tests.c fips/aes_self_tests.c
 lsrc_aarch64    += fips/self_tests_generic.c fips/aes_self_tests.c
+lsrc_riscv64    += fips/self_tests_generic.c
 lsrc            += fips/sha_self_tests.c
 
 lsrc_x86_64     += fips/asm_self_tests.asm

--- a/md5_mb/Makefile.am
+++ b/md5_mb/Makefile.am
@@ -69,6 +69,9 @@ lsrc_aarch64 += md5_mb/md5_ctx_base.c \
 		md5_mb/aarch64/md5_mb_sve.S  \
 		md5_mb/aarch64/md5_mb_multibinary.S
 
+lsrc_riscv64 += md5_mb/md5_ctx_base.c \
+		     md5_mb/md5_ctx_base_aliases.c
+
 lsrc_base_aliases += md5_mb/md5_ctx_base.c \
 		     md5_mb/md5_ctx_base_aliases.c
 

--- a/mh_sha1/Makefile.am
+++ b/mh_sha1/Makefile.am
@@ -57,6 +57,10 @@ lsrc_aarch64 += \
 		mh_sha1/aarch64/mh_sha1_block_ce.S \
 		mh_sha1/aarch64/mh_sha1_ce.c
 
+lsrc_riscv64 += \
+		$(lsrc_mh_sha1_base) \
+		mh_sha1/mh_sha1_base_aliases.c
+
 lsrc_base_aliases += \
 		$(lsrc_mh_sha1_base) \
 		mh_sha1/mh_sha1_base_aliases.c

--- a/mh_sha1_murmur3_x64_128/Makefile.am
+++ b/mh_sha1_murmur3_x64_128/Makefile.am
@@ -56,6 +56,12 @@ lsrc_aarch64 += $(lsrc_murmur)	\
 		mh_sha1_murmur3_x64_128/aarch64/mh_sha1_murmur3_block_asimd.S \
 		mh_sha1_murmur3_x64_128/aarch64/mh_sha1_murmur3_multibinary.S
 
+lsrc_riscv64 += $(lsrc_murmur)	\
+		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128.c \
+		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128_finalize_base.c \
+		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128_update_base.c \
+		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128_base_aliases.c
+
 lsrc_base_aliases += $(lsrc_murmur)	\
 		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128.c \
 		mh_sha1_murmur3_x64_128/mh_sha1_murmur3_x64_128_finalize_base.c \

--- a/mh_sha256/Makefile.am
+++ b/mh_sha256/Makefile.am
@@ -62,6 +62,13 @@ lsrc_aarch64 += $(lsrc_sha256)	\
 		mh_sha256/mh_sha256_update_base.c \
 		mh_sha256/mh_sha256_block_base.c
 
+lsrc_riscv64 += $(lsrc_sha256)	\
+		mh_sha256/mh_sha256_base_aliases.c \
+		mh_sha256/mh_sha256.c \
+		mh_sha256/mh_sha256_finalize_base.c \
+		mh_sha256/mh_sha256_update_base.c \
+		mh_sha256/mh_sha256_block_base.c
+
 lsrc_base_aliases += $(lsrc_sha256)	\
 		mh_sha256/mh_sha256_base_aliases.c \
 		mh_sha256/mh_sha256.c \

--- a/rolling_hash/Makefile.am
+++ b/rolling_hash/Makefile.am
@@ -46,6 +46,10 @@ lsrc_aarch64	    += 	rolling_hash/rolling_hashx_base.c	\
 			rolling_hash/aarch64/rolling_hash2_aarch64_dispatcher.c \
 			rolling_hash/aarch64/rolling_hash2_run_until_unroll.S
 
+lsrc_riscv64   += 	rolling_hash/rolling_hashx_base.c	\
+			rolling_hash/rolling_hash2.c	\
+			rolling_hash/rolling_hash2_base_aliases.c
+
 src_include  += -I $(srcdir)/rolling_hash
 extern_hdrs  += include/rolling_hashx.h
 

--- a/sha1_mb/Makefile.am
+++ b/sha1_mb/Makefile.am
@@ -79,7 +79,9 @@ lsrc_aarch64 += sha1_mb/sha1_ctx_base.c \
 		sha1_mb/aarch64/sha1_mb_mgr_asimd.c	\
 		sha1_mb/aarch64/sha1_mb_aarch64_dispatcher.c
 
-
+lsrc_riscv64 += sha1_mb/sha1_ctx_base_aliases.c	\
+		sha1_mb/sha1_ctx_base.c \
+		sha1_mb/sha1_ref.c
 
 lsrc_base_aliases += sha1_mb/sha1_ctx_base_aliases.c	\
 		sha1_mb/sha1_ctx_base.c \

--- a/sha256_mb/Makefile.am
+++ b/sha256_mb/Makefile.am
@@ -79,6 +79,9 @@ lsrc_aarch64 += sha256_mb/aarch64/sha256_mb_multibinary.S \
 		sha256_mb/aarch64/sha256_mb_x3_ce.S	\
 		sha256_mb/aarch64/sha256_mb_x4_ce.S
 
+lsrc_riscv64 += sha256_mb/sha256_ctx_base_aliases.c	\
+		sha256_mb/sha256_ctx_base.c	\
+		sha256_mb/sha256_ref.c
 
 lsrc_base_aliases += sha256_mb/sha256_ctx_base_aliases.c	\
 		sha256_mb/sha256_ctx_base.c	\

--- a/sha512_mb/Makefile.am
+++ b/sha512_mb/Makefile.am
@@ -74,6 +74,9 @@ lsrc_aarch64 += sha512_mb/sha512_ctx_base.c			\
 		sha512_mb/aarch64/sha512_mb_x1_ce.S	\
 		sha512_mb/aarch64/sha512_mb_x2_ce.S
 
+lsrc_riscv64 += sha512_mb/sha512_ctx_base.c	\
+		sha512_mb/sha512_ctx_base_aliases.c
+
 lsrc_base_aliases += sha512_mb/sha512_ctx_base.c	\
 		sha512_mb/sha512_ctx_base_aliases.c
 

--- a/sm3_mb/Makefile.am
+++ b/sm3_mb/Makefile.am
@@ -54,6 +54,8 @@ lsrc_aarch64 += sm3_mb/sm3_ctx_base.c \
 	sm3_mb/aarch64/sm3_mb_asimd_x1.S	\
 	sm3_mb/aarch64/sm3_mb_asimd_x4.S
 
+lsrc_riscv64 += sm3_mb/sm3_ctx_base.c \
+	sm3_mb/sm3_ctx_base_aliases.c
 
 src_include += -I $(srcdir)/sm3_mb
 


### PR DESCRIPTION
This PR adds RISC-V 64 build support for ISA-L crypto and CI. 
Since AES has no base aliases available, `aes_self_tests` in fips will be disabled on RISC-V 64.
