### PR TITLE
docs: Remove colons from @warning tags

### DIFF
--- a/include/isa-l_crypto/md5_mb.h
+++ b/include/isa-l_crypto/md5_mb.h
@@ -33,7 +33,7 @@
 /**
  *  @file md5_mb.h
  *  @brief Multi-buffer CTX API MD5 function prototypes and structures
- *  @warning: MD5 is considered unsafe, so it is recommended to use SHA256 instead.
+ *  @warning MD5 is considered unsafe, so it is recommended to use SHA256 instead.
  *
  * Interface for multi-buffer MD5 functions
  *

--- a/include/isa-l_crypto/sha1_mb.h
+++ b/include/isa-l_crypto/sha1_mb.h
@@ -33,7 +33,7 @@
 /**
  *  @file sha1_mb.h
  *  @brief Multi-buffer CTX API SHA1 function prototypes and structures
- *  @warning: SHA1 is considered unsafe, so it is recommended to use SHA256 instead.
+ *  @warning SHA1 is considered unsafe, so it is recommended to use SHA256 instead.
  *
  * Interface for multi-buffer SHA1 functions
  *


### PR DESCRIPTION
The colons were getting rendered at the start of the line in the built PDFs.